### PR TITLE
Optimize Tile Entities

### DIFF
--- a/src/main/java/al132/alchemistry/blocks/AlchemistryBaseTile.java
+++ b/src/main/java/al132/alchemistry/blocks/AlchemistryBaseTile.java
@@ -31,7 +31,7 @@ abstract public class AlchemistryBaseTile extends ABaseInventoryTile implements 
         if (this.notifyTicks >= ticks) {
             if (this.world != null) {
                 BlockState state = this.world.getBlockState(this.getPos());
-                this.world.notifyBlockUpdate(this.pos, state, state, 6);
+                this.world.notifyBlockUpdate(this.pos, state, state, 22);
             }
             this.notifyTicks = 0;
         }

--- a/src/main/java/al132/alchemistry/blocks/AlchemistryBaseTile.java
+++ b/src/main/java/al132/alchemistry/blocks/AlchemistryBaseTile.java
@@ -3,6 +3,7 @@ package al132.alchemistry.blocks;
 import al132.alib.tiles.ABaseInventoryTile;
 import al132.alib.tiles.AutomationStackHandler;
 import al132.alib.tiles.GuiTile;
+import net.minecraft.block.BlockState;
 import net.minecraft.item.ItemStack;
 import net.minecraft.tileentity.ITickableTileEntity;
 import net.minecraft.tileentity.TileEntityType;
@@ -11,6 +12,7 @@ import net.minecraftforge.items.IItemHandlerModifiable;
 abstract public class AlchemistryBaseTile extends ABaseInventoryTile implements ITickableTileEntity, GuiTile {
 
     private int dirtyTicks = 0;
+    private int notifyTicks = 0;
 
     public AlchemistryBaseTile(TileEntityType<?> tileEntityTypeIn) {
         super(tileEntityTypeIn);
@@ -21,6 +23,17 @@ abstract public class AlchemistryBaseTile extends ABaseInventoryTile implements 
         if (this.dirtyTicks >= ticks) {
             this.markDirtyGUI();
             this.dirtyTicks = 0;
+        }
+    }
+
+    public void notifyGUIEvery(int ticks) {
+        this.notifyTicks++;
+        if (this.notifyTicks >= ticks) {
+            if (this.world != null) {
+                BlockState state = this.world.getBlockState(this.getPos());
+                this.world.notifyBlockUpdate(this.pos, state, state, 6);
+            }
+            this.notifyTicks = 0;
         }
     }
 

--- a/src/main/java/al132/alchemistry/blocks/atomizer/AtomizerTile.java
+++ b/src/main/java/al132/alchemistry/blocks/atomizer/AtomizerTile.java
@@ -36,7 +36,6 @@ public class AtomizerTile extends AlchemistryBaseTile implements EnergyTile, Flu
             protected void onContentsChanged() {
                 super.onContentsChanged();
                 updateRecipe();
-                notifyGUIEvery(5);
             }
         };
     }
@@ -54,14 +53,13 @@ public class AtomizerTile extends AlchemistryBaseTile implements EnergyTile, Flu
     @Override
     public void tick() {
         if (world.isRemote) return;
-        //this.energy.receiveEnergy(50, false);
         if (inputTank.getFluidAmount() > 0) {
             updateRecipe();
             if (canProcess()) {
                 process();
-                notifyGUIEvery(5);
             }
         }
+        notifyGUIEvery(5);
     }
 
     public boolean canProcess() {
@@ -128,12 +126,7 @@ public class AtomizerTile extends AlchemistryBaseTile implements EnergyTile, Flu
 
     @Override
     public IEnergyStorage initEnergy() {
-        return new CustomEnergyStorage(Config.ATOMIZER_ENERGY_CAPACITY.get()) {
-            @Override
-            public void onEnergyChanged() {
-                notifyGUIEvery(5);
-            }
-        };
+        return new CustomEnergyStorage(Config.ATOMIZER_ENERGY_CAPACITY.get());
     }
 
     @Override

--- a/src/main/java/al132/alchemistry/blocks/atomizer/AtomizerTile.java
+++ b/src/main/java/al132/alchemistry/blocks/atomizer/AtomizerTile.java
@@ -36,7 +36,7 @@ public class AtomizerTile extends AlchemistryBaseTile implements EnergyTile, Flu
             protected void onContentsChanged() {
                 super.onContentsChanged();
                 updateRecipe();
-                markDirtyGUI();
+                notifyGUIEvery(5);
             }
         };
     }
@@ -59,7 +59,7 @@ public class AtomizerTile extends AlchemistryBaseTile implements EnergyTile, Flu
             updateRecipe();
             if (canProcess()) {
                 process();
-                markDirtyGUI();//(5);
+                notifyGUIEvery(5);
             }
         }
     }
@@ -131,7 +131,7 @@ public class AtomizerTile extends AlchemistryBaseTile implements EnergyTile, Flu
         return new CustomEnergyStorage(Config.ATOMIZER_ENERGY_CAPACITY.get()) {
             @Override
             public void onEnergyChanged() {
-                markDirtyGUI();
+                notifyGUIEvery(5);
             }
         };
     }

--- a/src/main/java/al132/alchemistry/blocks/atomizer/AtomizerTile.java
+++ b/src/main/java/al132/alchemistry/blocks/atomizer/AtomizerTile.java
@@ -129,7 +129,12 @@ public class AtomizerTile extends AlchemistryBaseTile implements EnergyTile, Flu
 
     @Override
     public IEnergyStorage initEnergy() {
-        return new CustomEnergyStorage(Config.ATOMIZER_ENERGY_CAPACITY.get());
+        return new CustomEnergyStorage(Config.ATOMIZER_ENERGY_CAPACITY.get()) {
+            @Override
+            public void onEnergyChanged() {
+                markDirtyGUI();
+            }
+        };
     }
 
     @Override

--- a/src/main/java/al132/alchemistry/blocks/atomizer/AtomizerTile.java
+++ b/src/main/java/al132/alchemistry/blocks/atomizer/AtomizerTile.java
@@ -57,9 +57,11 @@ public class AtomizerTile extends AlchemistryBaseTile implements EnergyTile, Flu
         //this.energy.receiveEnergy(50, false);
         if (inputTank.getFluidAmount() > 0) {
             updateRecipe();
-            if (canProcess()) process();
+            if (canProcess()) {
+                process();
+                markDirtyGUI();//(5);
+            }
         }
-        markDirtyGUI();//(5);
     }
 
     public boolean canProcess() {

--- a/src/main/java/al132/alchemistry/blocks/atomizer/AtomizerTile.java
+++ b/src/main/java/al132/alchemistry/blocks/atomizer/AtomizerTile.java
@@ -91,7 +91,6 @@ public class AtomizerTile extends AlchemistryBaseTile implements EnergyTile, Flu
         super.read(state, compound);
         this.progressTicks = compound.getInt("progressTicks");
         inputTank.readFromNBT(compound.getCompound("inputTank"));
-        updateRecipe();
     }
 
     @Override

--- a/src/main/java/al132/alchemistry/blocks/combiner/CombinerTile.java
+++ b/src/main/java/al132/alchemistry/blocks/combiner/CombinerTile.java
@@ -70,7 +70,7 @@ public class CombinerTile extends AlchemistryBaseTile implements EnergyTile {
         if (recipeIsLocked) clientRecipeTarget.setStackInSlot(0, displayStack);
         if (!this.paused && canProcess()) {
             process();
-            this.markDirtyGUI();
+            this.notifyGUIEvery(5);
         }
     }
 
@@ -174,7 +174,7 @@ public class CombinerTile extends AlchemistryBaseTile implements EnergyTile {
         return new CustomEnergyStorage(Config.COMBINER_ENERGY_CAPACITY.get()) {
             @Override
             public void onEnergyChanged() {
-                markDirtyGUI();
+                notifyGUIEvery(5);
             }
         };
     }

--- a/src/main/java/al132/alchemistry/blocks/combiner/CombinerTile.java
+++ b/src/main/java/al132/alchemistry/blocks/combiner/CombinerTile.java
@@ -56,8 +56,10 @@ public class CombinerTile extends AlchemistryBaseTile implements EnergyTile {
         if (currentRecipe != null && currentRecipe.output != null)
             displayStack = currentRecipe.output.getStack().copy();
         if (recipeIsLocked) clientRecipeTarget.setStackInSlot(0, displayStack);
-        if (!this.paused && canProcess()) process();
-        this.markDirtyClient();
+        if (!this.paused && canProcess()) {
+            process();
+            this.markDirtyClient();
+        }
     }
 
     public boolean canProcess() {

--- a/src/main/java/al132/alchemistry/blocks/combiner/CombinerTile.java
+++ b/src/main/java/al132/alchemistry/blocks/combiner/CombinerTile.java
@@ -70,7 +70,7 @@ public class CombinerTile extends AlchemistryBaseTile implements EnergyTile {
         if (recipeIsLocked) clientRecipeTarget.setStackInSlot(0, displayStack);
         if (!this.paused && canProcess()) {
             process();
-            this.markDirtyClient();
+            this.markDirtyGUI();
         }
     }
 
@@ -116,18 +116,8 @@ public class CombinerTile extends AlchemistryBaseTile implements EnergyTile {
         this.recipeIsLocked = compound.getBoolean("recipeIsLocked");
         this.progressTicks = compound.getInt("progressTicks");
         this.paused = compound.getBoolean("paused");
-        // clientRecipeTarget.deserializeNBT(compound.getCompound("recipeTarget"));
-        try {
-            if (recipeIsLocked) {
-                this.updateRecipe(ItemStack.read(compound.getCompound("recipeTarget")));
-            } else {
-                this.updateRecipe();
-                clientRecipeTarget.setStackInSlot(0, ItemStack.EMPTY);
-            }
-        } catch (NullPointerException npe) {
-            this.recipeTargetNBT = compound.getCompound("recipeTarget");
-            clientRecipeTarget.setStackInSlot(0, ItemStack.read(compound.getCompound("recipeTarget")));
-        }
+        this.recipeTargetNBT = compound.getCompound("recipeTarget");
+        clientRecipeTarget.setStackInSlot(0, ItemStack.read(compound.getCompound("recipeTarget")));
     }
 
     @Override

--- a/src/main/java/al132/alchemistry/blocks/combiner/CombinerTile.java
+++ b/src/main/java/al132/alchemistry/blocks/combiner/CombinerTile.java
@@ -63,15 +63,14 @@ public class CombinerTile extends AlchemistryBaseTile implements EnergyTile {
         }
 
         if (world.isRemote) return;
-        //this.energy.receiveEnergy(50, false);
         ItemStack displayStack = ItemStack.EMPTY;
         if (currentRecipe != null && currentRecipe.output != null)
             displayStack = currentRecipe.output.getStack().copy();
         if (recipeIsLocked) clientRecipeTarget.setStackInSlot(0, displayStack);
         if (!this.paused && canProcess()) {
             process();
-            this.notifyGUIEvery(5);
         }
+        this.notifyGUIEvery(5);
     }
 
     public boolean canProcess() {
@@ -171,12 +170,7 @@ public class CombinerTile extends AlchemistryBaseTile implements EnergyTile {
 
     @Override
     public IEnergyStorage initEnergy() {
-        return new CustomEnergyStorage(Config.COMBINER_ENERGY_CAPACITY.get()) {
-            @Override
-            public void onEnergyChanged() {
-                notifyGUIEvery(5);
-            }
-        };
+        return new CustomEnergyStorage(Config.COMBINER_ENERGY_CAPACITY.get());
     }
 
     @Override

--- a/src/main/java/al132/alchemistry/blocks/combiner/CombinerTile.java
+++ b/src/main/java/al132/alchemistry/blocks/combiner/CombinerTile.java
@@ -167,7 +167,12 @@ public class CombinerTile extends AlchemistryBaseTile implements EnergyTile {
 
     @Override
     public IEnergyStorage initEnergy() {
-        return new CustomEnergyStorage(Config.COMBINER_ENERGY_CAPACITY.get());
+        return new CustomEnergyStorage(Config.COMBINER_ENERGY_CAPACITY.get()) {
+            @Override
+            public void onEnergyChanged() {
+                markDirtyGUI();
+            }
+        };
     }
 
     @Override

--- a/src/main/java/al132/alchemistry/blocks/dissolver/DissolverRegistry.java
+++ b/src/main/java/al132/alchemistry/blocks/dissolver/DissolverRegistry.java
@@ -5,12 +5,14 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.world.World;
 
 import javax.annotation.Nullable;
+import java.util.HashMap;
 import java.util.List;
 import java.util.stream.Collectors;
 
 public class DissolverRegistry {
 
     private static List<DissolverRecipe> recipes = null;
+    private static HashMap<ItemStack, DissolverRecipe> cache = new HashMap<>();
 
     public static List<DissolverRecipe> getRecipes(World world) {
         if (recipes == null) {
@@ -24,14 +26,20 @@ public class DissolverRegistry {
 
     @Nullable
     public static DissolverRecipe match(World world,ItemStack input, boolean quantitySensitive) {
+        DissolverRecipe cachedRecipe = cache.getOrDefault(input, null);
+        if (cachedRecipe != null) return cachedRecipe;
+
         for (DissolverRecipe recipe : getRecipes(world)) {
             if (recipe.inputIngredient != null) {
                 for (ItemStack recipeStack : recipe.inputIngredient.ingredient.getMatchingStacks().clone()) {
                     if (ItemStack.areItemsEqual(recipeStack, input)) {
                         // && (input.itemDamage == recipeStack.itemDamage
                         //|| recipeStack.itemDamage == OreDictionary.WILDCARD_VALUE)) {
-                        if (quantitySensitive && input.getCount() >= recipeStack.getCount()) return recipe.copy();
-                        else if (!quantitySensitive) return recipe.copy();
+                        if (quantitySensitive && input.getCount() >= recipeStack.getCount() || !quantitySensitive) {
+                            cachedRecipe = recipe.copy();
+                            cache.put(input, cachedRecipe);
+                            return cachedRecipe;
+                        }
                     }
                 }
             } else {

--- a/src/main/java/al132/alchemistry/blocks/dissolver/DissolverTile.java
+++ b/src/main/java/al132/alchemistry/blocks/dissolver/DissolverTile.java
@@ -35,14 +35,13 @@ public class DissolverTile extends AlchemistryBaseTile implements EnergyTile {
     @Override
     public void tick() {
         if (world.isRemote) return;
-        //this.energy.receiveEnergy(50, false);
         if (currentRecipe == null) updateRecipe();
         if (!getInput().getStackInSlot(0).isEmpty() || !outputBuffer.isEmpty()) {
             if (canProcess()) {
                 process();
-                this.notifyGUIEvery(5);
             }
         }
+        this.notifyGUIEvery(5);
     }
 
     public boolean canProcess() {
@@ -115,7 +114,6 @@ public class DissolverTile extends AlchemistryBaseTile implements EnergyTile {
             public void onContentsChanged(int slot) {
                 super.onContentsChanged(slot);
                 updateRecipe();
-                notifyGUIEvery(5);
             }
         };
     }
@@ -153,14 +151,7 @@ public class DissolverTile extends AlchemistryBaseTile implements EnergyTile {
 
     @Override
     public IEnergyStorage initEnergy() {
-        return new CustomEnergyStorage(Config.DISSOLVER_ENERGY_CAPACITY.get()) {
-            @Override
-            public void onEnergyChanged() {
-                notifyGUIEvery(5);
-            }
-        };
-
-
+        return new CustomEnergyStorage(Config.DISSOLVER_ENERGY_CAPACITY.get());
     }
 
     @Override

--- a/src/main/java/al132/alchemistry/blocks/dissolver/DissolverTile.java
+++ b/src/main/java/al132/alchemistry/blocks/dissolver/DissolverTile.java
@@ -37,9 +37,11 @@ public class DissolverTile extends AlchemistryBaseTile implements EnergyTile {
         if (world.isRemote) return;
         //this.energy.receiveEnergy(50, false);
         if (!getInput().getStackInSlot(0).isEmpty() || !outputBuffer.isEmpty()) {
-            if (canProcess()) process();
+            if (canProcess()) {
+                process();
+                this.markDirtyGUI();
+            }
         }
-        //this.markDirtyGUI();
     }
 
     public boolean canProcess() {

--- a/src/main/java/al132/alchemistry/blocks/dissolver/DissolverTile.java
+++ b/src/main/java/al132/alchemistry/blocks/dissolver/DissolverTile.java
@@ -40,7 +40,7 @@ public class DissolverTile extends AlchemistryBaseTile implements EnergyTile {
         if (!getInput().getStackInSlot(0).isEmpty() || !outputBuffer.isEmpty()) {
             if (canProcess()) {
                 process();
-                this.markDirtyGUI();
+                this.notifyGUIEvery(5);
             }
         }
     }
@@ -115,7 +115,7 @@ public class DissolverTile extends AlchemistryBaseTile implements EnergyTile {
             public void onContentsChanged(int slot) {
                 super.onContentsChanged(slot);
                 updateRecipe();
-                markDirtyGUI();
+                notifyGUIEvery(5);
             }
         };
     }
@@ -156,7 +156,7 @@ public class DissolverTile extends AlchemistryBaseTile implements EnergyTile {
         return new CustomEnergyStorage(Config.DISSOLVER_ENERGY_CAPACITY.get()) {
             @Override
             public void onEnergyChanged() {
-                markDirtyGUI();
+                notifyGUIEvery(5);
             }
         };
 

--- a/src/main/java/al132/alchemistry/blocks/dissolver/DissolverTile.java
+++ b/src/main/java/al132/alchemistry/blocks/dissolver/DissolverTile.java
@@ -36,6 +36,7 @@ public class DissolverTile extends AlchemistryBaseTile implements EnergyTile {
     public void tick() {
         if (world.isRemote) return;
         //this.energy.receiveEnergy(50, false);
+        if (currentRecipe == null) updateRecipe();
         if (!getInput().getStackInSlot(0).isEmpty() || !outputBuffer.isEmpty()) {
             if (canProcess()) {
                 process();
@@ -140,8 +141,6 @@ public class DissolverTile extends AlchemistryBaseTile implements EnergyTile {
         super.read(state, compound);
         this.outputSuccessful = compound.getBoolean("OutputSuccessful");
         ItemStackHelper.loadAllItems(compound.getCompound("OutputBuffer"), outputBuffer);
-        updateRecipe();
-        markDirtyGUI();
     }
 
     @Override

--- a/src/main/java/al132/alchemistry/blocks/evaporator/EvaporatorTile.java
+++ b/src/main/java/al132/alchemistry/blocks/evaporator/EvaporatorTile.java
@@ -33,7 +33,7 @@ public class EvaporatorTile extends AlchemistryBaseTile implements FluidTile {
             @Override
             protected void onContentsChanged() {
                 super.onContentsChanged();
-                markDirtyGUI();
+                notifyGUIEvery(5);
             }
         };
     }
@@ -47,7 +47,7 @@ public class EvaporatorTile extends AlchemistryBaseTile implements FluidTile {
         }
         if (canProcess()) {
             process();
-            markDirtyGUI();//(5);
+            notifyGUIEvery(5);
         }
     }
 

--- a/src/main/java/al132/alchemistry/blocks/evaporator/EvaporatorTile.java
+++ b/src/main/java/al132/alchemistry/blocks/evaporator/EvaporatorTile.java
@@ -45,8 +45,10 @@ public class EvaporatorTile extends AlchemistryBaseTile implements FluidTile {
             this.currentRecipe = EvaporatorRegistry.getRecipes(world).stream()
                     .filter(recipe -> fluidTank.getFluid().containsFluid(recipe.input)).findFirst().orElse(null);
         }
-        if (canProcess()) process();
-        markDirtyClient();//(5);
+        if (canProcess()) {
+            process();
+            markDirtyClient();//(5);
+        }
     }
 
 

--- a/src/main/java/al132/alchemistry/blocks/evaporator/EvaporatorTile.java
+++ b/src/main/java/al132/alchemistry/blocks/evaporator/EvaporatorTile.java
@@ -33,7 +33,6 @@ public class EvaporatorTile extends AlchemistryBaseTile implements FluidTile {
             @Override
             protected void onContentsChanged() {
                 super.onContentsChanged();
-                notifyGUIEvery(5);
             }
         };
     }
@@ -47,8 +46,8 @@ public class EvaporatorTile extends AlchemistryBaseTile implements FluidTile {
         }
         if (canProcess()) {
             process();
-            notifyGUIEvery(5);
         }
+        notifyGUIEvery(5);
     }
 
 

--- a/src/main/java/al132/alchemistry/blocks/evaporator/EvaporatorTile.java
+++ b/src/main/java/al132/alchemistry/blocks/evaporator/EvaporatorTile.java
@@ -33,7 +33,7 @@ public class EvaporatorTile extends AlchemistryBaseTile implements FluidTile {
             @Override
             protected void onContentsChanged() {
                 super.onContentsChanged();
-                markDirtyClient();
+                markDirtyGUI();
             }
         };
     }
@@ -47,7 +47,7 @@ public class EvaporatorTile extends AlchemistryBaseTile implements FluidTile {
         }
         if (canProcess()) {
             process();
-            markDirtyClient();//(5);
+            markDirtyGUI();//(5);
         }
     }
 

--- a/src/main/java/al132/alchemistry/blocks/fission/FissionTile.java
+++ b/src/main/java/al132/alchemistry/blocks/fission/FissionTile.java
@@ -96,8 +96,8 @@ public class FissionTile extends AlchemistryBaseTile implements EnergyTile {
 
         if (canProcess()) {
             process();
-            this.notifyGUIEvery(5);
         }
+        this.notifyGUIEvery(5);
     }
 
     public boolean canProcess() {
@@ -248,12 +248,7 @@ public class FissionTile extends AlchemistryBaseTile implements EnergyTile {
 
     @Override
     public IEnergyStorage initEnergy() {
-        return new CustomEnergyStorage(Config.FISSION_ENERGY_CAPACITY.get()) {
-            @Override
-            public void onEnergyChanged() {
-                notifyGUIEvery(5);
-            }
-        };
+        return new CustomEnergyStorage(Config.FISSION_ENERGY_CAPACITY.get());
     }
 
     @Override

--- a/src/main/java/al132/alchemistry/blocks/fission/FissionTile.java
+++ b/src/main/java/al132/alchemistry/blocks/fission/FissionTile.java
@@ -241,7 +241,12 @@ public class FissionTile extends AlchemistryBaseTile implements EnergyTile {
 
     @Override
     public IEnergyStorage initEnergy() {
-        return new CustomEnergyStorage(Config.FISSION_ENERGY_CAPACITY.get());
+        return new CustomEnergyStorage(Config.FISSION_ENERGY_CAPACITY.get()) {
+            @Override
+            public void onEnergyChanged() {
+                markDirtyGUI();
+            }
+        };
     }
 
     @Override

--- a/src/main/java/al132/alchemistry/blocks/fission/FissionTile.java
+++ b/src/main/java/al132/alchemistry/blocks/fission/FissionTile.java
@@ -86,8 +86,10 @@ public class FissionTile extends AlchemistryBaseTile implements EnergyTile {
                 } else if (currentStatus != STANDBY) world.setBlockState(pos, state.with(STATUS, STANDBY));
             } else if (currentStatus != OFF) world.setBlockState(pos, state.with(STATUS, OFF));
 
-            if (canProcess()) process();
-            this.markDirtyClient();
+            if (canProcess()) {
+                process();
+                this.markDirtyClient();
+            }
         }
     }
 

--- a/src/main/java/al132/alchemistry/blocks/fission/FissionTile.java
+++ b/src/main/java/al132/alchemistry/blocks/fission/FissionTile.java
@@ -96,7 +96,7 @@ public class FissionTile extends AlchemistryBaseTile implements EnergyTile {
 
         if (canProcess()) {
             process();
-            this.markDirtyGUI();
+            this.notifyGUIEvery(5);
         }
     }
 
@@ -251,7 +251,7 @@ public class FissionTile extends AlchemistryBaseTile implements EnergyTile {
         return new CustomEnergyStorage(Config.FISSION_ENERGY_CAPACITY.get()) {
             @Override
             public void onEnergyChanged() {
-                markDirtyGUI();
+                notifyGUIEvery(5);
             }
         };
     }

--- a/src/main/java/al132/alchemistry/blocks/fusion/FusionTile.java
+++ b/src/main/java/al132/alchemistry/blocks/fusion/FusionTile.java
@@ -44,6 +44,8 @@ public class FusionTile extends AlchemistryBaseTile implements EnergyTile {
     IItemHandler leftInput;
     IItemHandler rightInput;
 
+    boolean firstTick = true;
+
     public FusionTile() {
         super(Ref.fusionTile);
     }
@@ -52,6 +54,11 @@ public class FusionTile extends AlchemistryBaseTile implements EnergyTile {
     @Override
     public void tick() {
         if (world.isRemote) return;
+        if (firstTick) {
+            refreshRecipe();
+            firstTick = false;
+        }
+
         checkMultiblockTicks++;
         if (checkMultiblockTicks >= 20) {
             updateMultiblock();
@@ -68,7 +75,7 @@ public class FusionTile extends AlchemistryBaseTile implements EnergyTile {
         } else if (currentStatus != OFF) world.setBlockState(pos, state.with(STATUS, OFF));
         if (canProcess()) {
             process();
-            this.markDirtyClient();
+            this.markDirtyGUI();
         }
     }
 
@@ -114,13 +121,13 @@ public class FusionTile extends AlchemistryBaseTile implements EnergyTile {
     public void read(BlockState state, CompoundNBT compound) {
         super.read(state, compound);
         this.progressTicks = compound.getInt("progressTicks");
-        this.refreshRecipe();
-        this.updateMultiblock();
+        this.isValidMultiblock = compound.getBoolean("isValidMultiblock");
     }
 
     @Override
     public CompoundNBT write(CompoundNBT compound) {
         compound.putInt("progressTicks", progressTicks);
+        compound.putBoolean("isValidMultiblock", isValidMultiblock);
         return super.write(compound);
     }
 

--- a/src/main/java/al132/alchemistry/blocks/fusion/FusionTile.java
+++ b/src/main/java/al132/alchemistry/blocks/fusion/FusionTile.java
@@ -66,8 +66,10 @@ public class FusionTile extends AlchemistryBaseTile implements EnergyTile {
                 if (currentStatus != ON) this.world.setBlockState(this.pos, state.with(STATUS, ON));
             } else if (currentStatus != STANDBY) world.setBlockState(pos, state.with(STATUS, STANDBY));
         } else if (currentStatus != OFF) world.setBlockState(pos, state.with(STATUS, OFF));
-        if (canProcess()) process();
-        this.markDirtyClient();
+        if (canProcess()) {
+            process();
+            this.markDirtyClient();
+        }
     }
 
     public boolean canProcess() {

--- a/src/main/java/al132/alchemistry/blocks/fusion/FusionTile.java
+++ b/src/main/java/al132/alchemistry/blocks/fusion/FusionTile.java
@@ -75,8 +75,8 @@ public class FusionTile extends AlchemistryBaseTile implements EnergyTile {
         } else if (currentStatus != OFF) world.setBlockState(pos, state.with(STATUS, OFF));
         if (canProcess()) {
             process();
-            this.notifyGUIEvery(5);
         }
+        this.notifyGUIEvery(5);
     }
 
     public boolean canProcess() {
@@ -258,12 +258,7 @@ public class FusionTile extends AlchemistryBaseTile implements EnergyTile {
 
     @Override
     public IEnergyStorage initEnergy() {
-        return new CustomEnergyStorage(Config.FUSION_ENERGY_CAPACITY.get()) {
-            @Override
-            public void onEnergyChanged() {
-                notifyGUIEvery(5);
-            }
-        };
+        return new CustomEnergyStorage(Config.FUSION_ENERGY_CAPACITY.get());
     }
 
     @Override

--- a/src/main/java/al132/alchemistry/blocks/fusion/FusionTile.java
+++ b/src/main/java/al132/alchemistry/blocks/fusion/FusionTile.java
@@ -75,7 +75,7 @@ public class FusionTile extends AlchemistryBaseTile implements EnergyTile {
         } else if (currentStatus != OFF) world.setBlockState(pos, state.with(STATUS, OFF));
         if (canProcess()) {
             process();
-            this.markDirtyGUI();
+            this.notifyGUIEvery(5);
         }
     }
 
@@ -261,7 +261,7 @@ public class FusionTile extends AlchemistryBaseTile implements EnergyTile {
         return new CustomEnergyStorage(Config.FUSION_ENERGY_CAPACITY.get()) {
             @Override
             public void onEnergyChanged() {
-                markDirtyGUI();
+                notifyGUIEvery(5);
             }
         };
     }

--- a/src/main/java/al132/alchemistry/blocks/fusion/FusionTile.java
+++ b/src/main/java/al132/alchemistry/blocks/fusion/FusionTile.java
@@ -251,7 +251,12 @@ public class FusionTile extends AlchemistryBaseTile implements EnergyTile {
 
     @Override
     public IEnergyStorage initEnergy() {
-        return new CustomEnergyStorage(Config.FUSION_ENERGY_CAPACITY.get());
+        return new CustomEnergyStorage(Config.FUSION_ENERGY_CAPACITY.get()) {
+            @Override
+            public void onEnergyChanged() {
+                markDirtyGUI();
+            }
+        };
     }
 
     @Override

--- a/src/main/java/al132/alchemistry/blocks/liquifier/LiquifierTile.java
+++ b/src/main/java/al132/alchemistry/blocks/liquifier/LiquifierTile.java
@@ -51,16 +51,14 @@ public class LiquifierTile extends AlchemistryBaseTile implements EnergyTile, Fl
 
     @Override
     public void tick() {
-        if (!world.isRemote) {
-            //this.energy.receiveEnergy(50, false);
-            if (!this.getInput().getStackInSlot(0).isEmpty()) {
-                updateRecipe();
-                if (canProcess()) {
-                    process();
-                    this.notifyGUIEvery(5);
-                }
+        if (world.isRemote) return;
+        if (!this.getInput().getStackInSlot(0).isEmpty()) {
+            updateRecipe();
+            if (canProcess()) {
+                process();
             }
         }
+        this.notifyGUIEvery(5);
     }
 
     public boolean canProcess() {

--- a/src/main/java/al132/alchemistry/blocks/liquifier/LiquifierTile.java
+++ b/src/main/java/al132/alchemistry/blocks/liquifier/LiquifierTile.java
@@ -55,9 +55,11 @@ public class LiquifierTile extends AlchemistryBaseTile implements EnergyTile, Fl
             //this.energy.receiveEnergy(50, false);
             if (!this.getInput().getStackInSlot(0).isEmpty()) {
                 updateRecipe();
-                if (canProcess()) process();
+                if (canProcess()) {
+                    process();
+                    this.markDirtyGUI();
+                }
             }
-            this.markDirtyGUIEvery(5);
         }
     }
 

--- a/src/main/java/al132/alchemistry/blocks/liquifier/LiquifierTile.java
+++ b/src/main/java/al132/alchemistry/blocks/liquifier/LiquifierTile.java
@@ -89,7 +89,6 @@ public class LiquifierTile extends AlchemistryBaseTile implements EnergyTile, Fl
         super.read(state, compound);
         this.progressTicks = compound.getInt("progressTicks");
         this.outputTank.readFromNBT(compound.getCompound("outputTank"));
-        updateRecipe();
     }
 
     @Override

--- a/src/main/java/al132/alchemistry/blocks/liquifier/LiquifierTile.java
+++ b/src/main/java/al132/alchemistry/blocks/liquifier/LiquifierTile.java
@@ -127,7 +127,12 @@ public class LiquifierTile extends AlchemistryBaseTile implements EnergyTile, Fl
 
     @Override
     public IEnergyStorage initEnergy() {
-        return new CustomEnergyStorage(Config.LIQUIFIER_ENERGY_CAPACITY.get());
+        return new CustomEnergyStorage(Config.LIQUIFIER_ENERGY_CAPACITY.get()) {
+            @Override
+            public void onEnergyChanged() {
+                markDirtyGUI();
+            }
+        };
     }
 
     @Override

--- a/src/main/java/al132/alchemistry/blocks/liquifier/LiquifierTile.java
+++ b/src/main/java/al132/alchemistry/blocks/liquifier/LiquifierTile.java
@@ -124,12 +124,7 @@ public class LiquifierTile extends AlchemistryBaseTile implements EnergyTile, Fl
 
     @Override
     public IEnergyStorage initEnergy() {
-        return new CustomEnergyStorage(Config.LIQUIFIER_ENERGY_CAPACITY.get()) {
-            @Override
-            public void onEnergyChanged() {
-                notifyGUIEvery(5);
-            }
-        };
+        return new CustomEnergyStorage(Config.LIQUIFIER_ENERGY_CAPACITY.get());
     }
 
     @Override

--- a/src/main/java/al132/alchemistry/blocks/liquifier/LiquifierTile.java
+++ b/src/main/java/al132/alchemistry/blocks/liquifier/LiquifierTile.java
@@ -57,7 +57,7 @@ public class LiquifierTile extends AlchemistryBaseTile implements EnergyTile, Fl
                 updateRecipe();
                 if (canProcess()) {
                     process();
-                    this.markDirtyGUI();
+                    this.notifyGUIEvery(5);
                 }
             }
         }
@@ -129,7 +129,7 @@ public class LiquifierTile extends AlchemistryBaseTile implements EnergyTile, Fl
         return new CustomEnergyStorage(Config.LIQUIFIER_ENERGY_CAPACITY.get()) {
             @Override
             public void onEnergyChanged() {
-                markDirtyGUI();
+                notifyGUIEvery(5);
             }
         };
     }

--- a/src/main/java/al132/alchemistry/network/CombinerButtonPkt.java
+++ b/src/main/java/al132/alchemistry/network/CombinerButtonPkt.java
@@ -45,7 +45,7 @@ public class CombinerButtonPkt {
                     tile.paused = !(tile.paused);
                 }
                 if (!tile.recipeIsLocked) tile.clientRecipeTarget.setStackInSlot(0, ItemStack.EMPTY);
-                tile.markDirtyClient();
+                //tile.markDirtyClient();
             });
             ctx.get().setPacketHandled(true);
         }

--- a/src/main/java/al132/alchemistry/network/CombinerTransferPkt.java
+++ b/src/main/java/al132/alchemistry/network/CombinerTransferPkt.java
@@ -46,7 +46,7 @@ public class CombinerTransferPkt {
                     tile.currentRecipe = CombinerRegistry.matchOutput(playerEntity.world, output.copy());
                 }
                 //System.out.println("Handling packet: {" + message.outputStack + "}");
-                tile.markDirtyClient();
+                //tile.markDirtyClient();
             });
             ctx.get().setPacketHandled(true);
         }


### PR DESCRIPTION
- This happens because the matchInput/matchOutput functions rely on
 world, world.getRecipeManager, and world.getRecipeManger.getRecipes
 being not null
- Resolves #153