### PR TITLE
Add new ReactorCoreBlock (was extending a pillared block class before…

### DIFF
--- a/src/main/java/com/smashingmods/alchemistry/api/block/AbstractAlchemistryBlock.java
+++ b/src/main/java/com/smashingmods/alchemistry/api/block/AbstractAlchemistryBlock.java
@@ -58,7 +58,7 @@ public abstract class AbstractAlchemistryBlock extends BaseEntityBlock {
     }
 
     @Override
-    @SuppressWarnings({"deprecation", "ConstantConditions"})
+    @SuppressWarnings("deprecation")
     public void onRemove(BlockState pState, Level pLevel, BlockPos pPos, BlockState pNewState, boolean pIsMoving) {
         if (pState.getBlock() != pNewState.getBlock()) {
             BlockEntity blockEntity = pLevel.getBlockEntity(pPos);
@@ -66,26 +66,7 @@ public abstract class AbstractAlchemistryBlock extends BaseEntityBlock {
                 processingBlockEntity.dropContents();
             }
             if (blockEntity instanceof AbstractReactorBlockEntity reactorBlockEntity) {
-                if (reactorBlockEntity.getReactorEnergyBlockEntity() != null) {
-                    BlockState energyState = reactorBlockEntity.getReactorEnergyBlockEntity().getBlockState();
-                    BlockPos energyPos = reactorBlockEntity.getReactorEnergyBlockEntity().getBlockPos();
-                    pLevel.setBlock(energyPos, Blocks.AIR.defaultBlockState(), 7);
-                    pLevel.setBlock(energyPos, energyState, 7);
-                }
-
-                if (reactorBlockEntity.getReactorInputBlockEntity() != null) {
-                    BlockState inputState = reactorBlockEntity.getReactorInputBlockEntity().getBlockState();
-                    BlockPos inputPos = reactorBlockEntity.getReactorInputBlockEntity().getBlockPos();
-                    pLevel.setBlock(inputPos, Blocks.AIR.defaultBlockState(), 7);
-                    pLevel.setBlock(inputPos, inputState, 7);
-                }
-
-                if (reactorBlockEntity.getReactorOutputBlockEntity() != null) {
-                    BlockState outputState = reactorBlockEntity.getReactorOutputBlockEntity().getBlockState();
-                    BlockPos outputPos = reactorBlockEntity.getReactorOutputBlockEntity().getBlockPos();
-                    pLevel.setBlock(outputPos, Blocks.AIR.defaultBlockState(), 7);
-                    pLevel.setBlock(outputPos, outputState, 7);
-                }
+                reactorBlockEntity.onRemove();
             }
         }
         super.onRemove(pState, pLevel, pPos, pNewState, pIsMoving);

--- a/src/main/java/com/smashingmods/alchemistry/api/blockentity/AbstractProcessingBlockEntity.java
+++ b/src/main/java/com/smashingmods/alchemistry/api/blockentity/AbstractProcessingBlockEntity.java
@@ -11,7 +11,9 @@ import net.minecraft.network.chat.TranslatableComponent;
 import net.minecraft.network.protocol.Packet;
 import net.minecraft.network.protocol.game.ClientGamePacketListener;
 import net.minecraft.network.protocol.game.ClientboundBlockEntityDataPacket;
-import net.minecraft.world.*;
+import net.minecraft.world.InteractionHand;
+import net.minecraft.world.MenuProvider;
+import net.minecraft.world.Nameable;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.entity.BlockEntity;
@@ -89,8 +91,6 @@ public abstract class AbstractProcessingBlockEntity extends BlockEntity implemen
                 }
                 if (canProcessRecipe()) {
                     processRecipe();
-                } else {
-                    setProgress(0);
                 }
             }
         }

--- a/src/main/java/com/smashingmods/alchemistry/api/blockentity/ReactorShape.java
+++ b/src/main/java/com/smashingmods/alchemistry/api/blockentity/ReactorShape.java
@@ -149,4 +149,8 @@ public class ReactorShape {
     public BoundingBox getFullBoundingBox() {
         return fullBoundingBox;
     }
+
+    public BoundingBox getCoreBoundingBox() {
+        return core;
+    }
 }

--- a/src/main/java/com/smashingmods/alchemistry/client/jei/JEIPlugin.java
+++ b/src/main/java/com/smashingmods/alchemistry/client/jei/JEIPlugin.java
@@ -51,7 +51,7 @@ public class JEIPlugin implements IModPlugin {
         pRegistration.addRecipeClickArea(CombinerScreen.class, 64, 84, 30, 9, RecipeTypes.COMBINER);
         pRegistration.addRecipeClickArea(CompactorScreen.class, 74, 39, 30, 9, RecipeTypes.COMPACTOR);
         pRegistration.addRecipeClickArea(FissionControllerScreen.class, 58, 39, 30, 9, RecipeTypes.FISSION);
-        pRegistration.addRecipeClickArea(FusionControllerScreen.class, 58, 39, 30, 9, RecipeTypes.FUSION);
+        pRegistration.addRecipeClickArea(FusionControllerScreen.class, 91, 39, 30, 9, RecipeTypes.FUSION);
         pRegistration.addRecipeClickArea(LiquifierScreen.class, 90, 39, 30, 9, RecipeTypes.LIQUIFIER);
     }
 

--- a/src/main/java/com/smashingmods/alchemistry/common/block/dissolver/DissolverBlockEntity.java
+++ b/src/main/java/com/smashingmods/alchemistry/common/block/dissolver/DissolverBlockEntity.java
@@ -1,7 +1,7 @@
 package com.smashingmods.alchemistry.common.block.dissolver;
 
 import com.smashingmods.alchemistry.Config;
-import com.smashingmods.alchemistry.api.blockentity.*;
+import com.smashingmods.alchemistry.api.blockentity.AbstractInventoryBlockEntity;
 import com.smashingmods.alchemistry.api.blockentity.handler.CustomEnergyStorage;
 import com.smashingmods.alchemistry.api.blockentity.handler.CustomItemStackHandler;
 import com.smashingmods.alchemistry.common.recipe.dissolver.DissolverRecipe;
@@ -66,8 +66,6 @@ public class DissolverBlockEntity extends AbstractInventoryBlockEntity {
                 }
                 if (canProcessRecipe()) {
                     processRecipe();
-                } else {
-                    setProgress(0);
                 }
                 processBuffer();
             }
@@ -126,7 +124,7 @@ public class DissolverBlockEntity extends AbstractInventoryBlockEntity {
     }
 
     @Override
-    public <T extends Recipe<Inventory>> void setRecipe(T pRecipe) {
+    public <T extends Recipe<Inventory>> void setRecipe(@Nullable T pRecipe) {
         currentRecipe = (DissolverRecipe) pRecipe;
     }
 

--- a/src/main/java/com/smashingmods/alchemistry/common/block/fission/FissionControllerBlockEntity.java
+++ b/src/main/java/com/smashingmods/alchemistry/common/block/fission/FissionControllerBlockEntity.java
@@ -1,7 +1,9 @@
 package com.smashingmods.alchemistry.common.block.fission;
 
 import com.smashingmods.alchemistry.Config;
-import com.smashingmods.alchemistry.api.blockentity.*;
+import com.smashingmods.alchemistry.api.blockentity.AbstractReactorBlockEntity;
+import com.smashingmods.alchemistry.api.blockentity.PowerState;
+import com.smashingmods.alchemistry.api.blockentity.ReactorType;
 import com.smashingmods.alchemistry.api.blockentity.handler.CustomEnergyStorage;
 import com.smashingmods.alchemistry.api.blockentity.handler.CustomItemStackHandler;
 import com.smashingmods.alchemistry.common.recipe.fission.FissionRecipe;
@@ -56,6 +58,26 @@ public class FissionControllerBlockEntity extends AbstractReactorBlockEntity {
     }
 
     @Override
+    public void tick() {
+        if (!getPaused()) {
+            if (!getRecipeLocked()) {
+                updateRecipe();
+            }
+            if (canProcessRecipe()) {
+                setPowerState(PowerState.ON);
+                processRecipe();
+            } else {
+                if (getEnergyHandler().getEnergyStored() > Config.Common.fusionEnergyPerTick.get()) {
+                    setPowerState(PowerState.STANDBY);
+                } else {
+                    setPowerState(PowerState.OFF);
+                }
+            }
+        }
+        super.tick();
+    }
+
+    @Override
     public void updateRecipe() {
         if (level != null && !level.isClientSide()) {
             if (!getInputHandler().getStackInSlot(0).isEmpty()) {
@@ -96,7 +118,7 @@ public class FissionControllerBlockEntity extends AbstractReactorBlockEntity {
     }
 
     @Override
-    public <T extends Recipe<Inventory>> void setRecipe(T pRecipe) {
+    public <T extends Recipe<Inventory>> void setRecipe(@Nullable T pRecipe) {
         currentRecipe = (FissionRecipe) pRecipe;
     }
 

--- a/src/main/java/com/smashingmods/alchemistry/common/block/reactor/ReactorCoreBlock.java
+++ b/src/main/java/com/smashingmods/alchemistry/common/block/reactor/ReactorCoreBlock.java
@@ -1,0 +1,42 @@
+package com.smashingmods.alchemistry.common.block.reactor;
+
+import com.smashingmods.alchemistry.api.blockentity.PowerState;
+import com.smashingmods.alchemistry.api.blockentity.PowerStateProperty;
+import net.minecraft.core.BlockPos;
+import net.minecraft.world.item.context.BlockPlaceContext;
+import net.minecraft.world.level.BlockGetter;
+import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.RotatedPillarBlock;
+import net.minecraft.world.level.block.state.BlockBehaviour;
+import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.level.block.state.StateDefinition;
+import net.minecraft.world.level.material.Material;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.Objects;
+
+public class ReactorCoreBlock extends RotatedPillarBlock {
+
+    public ReactorCoreBlock() {
+        super(BlockBehaviour.Properties.of(Material.METAL).strength(2.0f));
+    }
+
+    @Override
+    public int getLightEmission(BlockState state, BlockGetter level, BlockPos pos) {
+        if (state.getValue(PowerStateProperty.POWER_STATE).equals(PowerState.ON)) {
+            return 15;
+        }
+        return 0;
+    }
+
+    @Override
+    protected void createBlockStateDefinition(StateDefinition.Builder<Block, BlockState> pBuilder) {
+        pBuilder.add(PowerStateProperty.POWER_STATE);
+        super.createBlockStateDefinition(pBuilder);
+    }
+
+    @Override
+    public @Nullable BlockState getStateForPlacement(BlockPlaceContext pContext) {
+        return Objects.requireNonNull(super.getStateForPlacement(pContext)).setValue(PowerStateProperty.POWER_STATE, PowerState.OFF);
+    }
+}

--- a/src/main/java/com/smashingmods/alchemistry/common/block/reactor/ReactorEnergyBlock.java
+++ b/src/main/java/com/smashingmods/alchemistry/common/block/reactor/ReactorEnergyBlock.java
@@ -4,19 +4,13 @@ import com.smashingmods.alchemistry.api.block.AbstractAlchemistryBlock;
 import com.smashingmods.alchemistry.api.blockentity.PowerState;
 import com.smashingmods.alchemistry.api.blockentity.PowerStateProperty;
 import net.minecraft.core.BlockPos;
-import net.minecraft.network.chat.Component;
-import net.minecraft.world.item.ItemStack;
-import net.minecraft.world.item.TooltipFlag;
 import net.minecraft.world.item.context.BlockPlaceContext;
-import net.minecraft.world.level.BlockGetter;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.block.state.StateDefinition;
 import net.minecraft.world.level.block.state.properties.BlockStateProperties;
 import org.jetbrains.annotations.Nullable;
-
-import java.util.List;
 
 public class ReactorEnergyBlock extends AbstractAlchemistryBlock {
     public ReactorEnergyBlock() {
@@ -45,11 +39,6 @@ public class ReactorEnergyBlock extends AbstractAlchemistryBlock {
             }
         }
         super.onRemove(pState, pLevel, pPos, pNewState, pIsMoving);
-    }
-
-    @Override
-    public void appendHoverText(ItemStack pStack, @Nullable BlockGetter pLevel, List<Component> pTooltip, TooltipFlag pFlag) {
-        super.appendHoverText(pStack, pLevel, pTooltip, pFlag);
     }
 }
 

--- a/src/main/java/com/smashingmods/alchemistry/common/block/reactor/ReactorInputBlock.java
+++ b/src/main/java/com/smashingmods/alchemistry/common/block/reactor/ReactorInputBlock.java
@@ -2,19 +2,13 @@ package com.smashingmods.alchemistry.common.block.reactor;
 
 import com.smashingmods.alchemistry.api.block.AbstractAlchemistryBlock;
 import net.minecraft.core.BlockPos;
-import net.minecraft.network.chat.Component;
-import net.minecraft.world.item.ItemStack;
-import net.minecraft.world.item.TooltipFlag;
 import net.minecraft.world.item.context.BlockPlaceContext;
-import net.minecraft.world.level.BlockGetter;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.block.state.StateDefinition;
 import net.minecraft.world.level.block.state.properties.BlockStateProperties;
 import org.jetbrains.annotations.Nullable;
-
-import java.util.List;
 
 public class ReactorInputBlock extends AbstractAlchemistryBlock {
     public ReactorInputBlock() {
@@ -41,10 +35,5 @@ public class ReactorInputBlock extends AbstractAlchemistryBlock {
             }
         }
         super.onRemove(pState, pLevel, pPos, pNewState, pIsMoving);
-    }
-
-    @Override
-    public void appendHoverText(ItemStack pStack, @Nullable BlockGetter pLevel, List<Component> pTooltip, TooltipFlag pFlag) {
-        super.appendHoverText(pStack, pLevel, pTooltip, pFlag);
     }
 }

--- a/src/main/java/com/smashingmods/alchemistry/common/block/reactor/ReactorOutputBlock.java
+++ b/src/main/java/com/smashingmods/alchemistry/common/block/reactor/ReactorOutputBlock.java
@@ -2,19 +2,13 @@ package com.smashingmods.alchemistry.common.block.reactor;
 
 import com.smashingmods.alchemistry.api.block.AbstractAlchemistryBlock;
 import net.minecraft.core.BlockPos;
-import net.minecraft.network.chat.Component;
-import net.minecraft.world.item.ItemStack;
-import net.minecraft.world.item.TooltipFlag;
 import net.minecraft.world.item.context.BlockPlaceContext;
-import net.minecraft.world.level.BlockGetter;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.block.state.StateDefinition;
 import net.minecraft.world.level.block.state.properties.BlockStateProperties;
 import org.jetbrains.annotations.Nullable;
-
-import java.util.List;
 
 public class ReactorOutputBlock extends AbstractAlchemistryBlock {
     public ReactorOutputBlock() {
@@ -41,10 +35,5 @@ public class ReactorOutputBlock extends AbstractAlchemistryBlock {
             }
         }
         super.onRemove(pState, pLevel, pPos, pNewState, pIsMoving);
-    }
-
-    @Override
-    public void appendHoverText(ItemStack pStack, @Nullable BlockGetter pLevel, List<Component> pTooltip, TooltipFlag pFlag) {
-        super.appendHoverText(pStack, pLevel, pTooltip, pFlag);
     }
 }

--- a/src/main/java/com/smashingmods/alchemistry/registry/BlockRegistry.java
+++ b/src/main/java/com/smashingmods/alchemistry/registry/BlockRegistry.java
@@ -7,10 +7,7 @@ import com.smashingmods.alchemistry.common.block.dissolver.DissolverBlock;
 import com.smashingmods.alchemistry.common.block.fission.FissionControllerBlock;
 import com.smashingmods.alchemistry.common.block.fusion.FusionControllerBlock;
 import com.smashingmods.alchemistry.common.block.liquifier.LiquifierBlock;
-import com.smashingmods.alchemistry.common.block.reactor.ReactorEnergyBlock;
-import com.smashingmods.alchemistry.common.block.reactor.ReactorGlassBlock;
-import com.smashingmods.alchemistry.common.block.reactor.ReactorInputBlock;
-import com.smashingmods.alchemistry.common.block.reactor.ReactorOutputBlock;
+import com.smashingmods.alchemistry.common.block.reactor.*;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.RotatedPillarBlock;
 import net.minecraft.world.level.block.state.BlockBehaviour;
@@ -33,8 +30,8 @@ public class BlockRegistry {
 
     public static final RegistryObject<Block> FISSION_CONTROLLER = BLOCKS.register("fission_chamber_controller", FissionControllerBlock::new);
     public static final RegistryObject<Block> FUSION_CONTROLLER = BLOCKS.register("fusion_chamber_controller", FusionControllerBlock::new);
-    public static final RegistryObject<RotatedPillarBlock> FISSION_CORE = BLOCKS.register("fission_core", () -> new RotatedPillarBlock(BlockBehaviour.Properties.of(Material.METAL).strength(2.0f)));
-    public static final RegistryObject<RotatedPillarBlock> FUSION_CORE = BLOCKS.register("fusion_core", () -> new RotatedPillarBlock(BlockBehaviour.Properties.of(Material.METAL).strength(2.0f)));
+    public static final RegistryObject<RotatedPillarBlock> FISSION_CORE = BLOCKS.register("fission_core", ReactorCoreBlock::new);
+    public static final RegistryObject<RotatedPillarBlock> FUSION_CORE = BLOCKS.register("fusion_core", ReactorCoreBlock::new);
     public static final RegistryObject<Block> REACTOR_CASING = BLOCKS.register("reactor_casing", () -> new Block(BlockBehaviour.Properties.of(Material.METAL).strength(2.0f)));
     public static final RegistryObject<Block> REACTOR_GLASS = BLOCKS.register("reactor_glass", ReactorGlassBlock::new);
     public static final RegistryObject<Block> REACTOR_ENERGY = BLOCKS.register("reactor_energy", ReactorEnergyBlock::new);


### PR DESCRIPTION
…) with power state.

Remove pointless overrides in some blocks.
Make machines and reactors keep their progress if they run out of power.
Reactor core now has a light level based on power state. When the reactor is on and running, it will output 15 light level.
Move reactor onRemove method into the abstract reactor class.