### PR TITLE
Minor refactors and fixes.

### DIFF
--- a/src/main/java/com/smashingmods/alchemistry/api/blockentity/AbstractProcessingBlockEntity.java
+++ b/src/main/java/com/smashingmods/alchemistry/api/blockentity/AbstractProcessingBlockEntity.java
@@ -112,7 +112,7 @@ public abstract class AbstractProcessingBlockEntity extends BlockEntity implemen
     }
 
     @Override
-    public boolean getRecipeLocked() {
+    public boolean isRecipeLocked() {
         return this.recipeLocked;
     }
 
@@ -122,7 +122,7 @@ public abstract class AbstractProcessingBlockEntity extends BlockEntity implemen
     }
 
     @Override
-    public boolean getPaused() {
+    public boolean isProcessingPaused() {
         return this.paused;
     }
 
@@ -154,8 +154,8 @@ public abstract class AbstractProcessingBlockEntity extends BlockEntity implemen
     @Override
     protected void saveAdditional(CompoundTag pTag) {
         pTag.putInt("progress", progress);
-        pTag.putBoolean("locked", getRecipeLocked());
-        pTag.putBoolean("paused", getPaused());
+        pTag.putBoolean("locked", isRecipeLocked());
+        pTag.putBoolean("paused", isProcessingPaused());
         pTag.put("energy", energyHandler.serializeNBT());
         super.saveAdditional(pTag);
     }

--- a/src/main/java/com/smashingmods/alchemistry/api/blockentity/ProcessingBlockEntity.java
+++ b/src/main/java/com/smashingmods/alchemistry/api/blockentity/ProcessingBlockEntity.java
@@ -25,11 +25,11 @@ public interface ProcessingBlockEntity {
 
     void incrementProgress();
 
-    boolean getRecipeLocked();
+    boolean isRecipeLocked();
 
     void setRecipeLocked(boolean pRecipeLocked);
 
-    boolean getPaused();
+    boolean isProcessingPaused();
 
     void setPaused(boolean pPaused);
 

--- a/src/main/java/com/smashingmods/alchemistry/api/container/AbstractAlchemistryScreen.java
+++ b/src/main/java/com/smashingmods/alchemistry/api/container/AbstractAlchemistryScreen.java
@@ -3,25 +3,48 @@ package com.smashingmods.alchemistry.api.container;
 import com.mojang.blaze3d.systems.RenderSystem;
 import com.mojang.blaze3d.vertex.*;
 import com.smashingmods.alchemistry.Alchemistry;
+import com.smashingmods.alchemistry.common.network.AlchemistryPacketHandler;
+import com.smashingmods.alchemistry.common.network.ProcessingButtonPacket;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.components.AbstractWidget;
+import net.minecraft.client.gui.components.Button;
 import net.minecraft.client.gui.components.Widget;
 import net.minecraft.client.gui.components.events.GuiEventListener;
 import net.minecraft.client.gui.narration.NarratableEntry;
 import net.minecraft.client.gui.screens.inventory.AbstractContainerScreen;
 import net.minecraft.client.renderer.texture.TextureAtlasSprite;
 import net.minecraft.network.chat.Component;
+import net.minecraft.network.chat.TranslatableComponent;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.entity.player.Inventory;
-import net.minecraft.world.inventory.AbstractContainerMenu;
 import net.minecraft.world.inventory.InventoryMenu;
 import net.minecraftforge.fluids.FluidStack;
+
 import java.util.List;
 
-public abstract class AbstractAlchemistryScreen<M extends AbstractContainerMenu> extends AbstractContainerScreen<M> {
+public abstract class AbstractAlchemistryScreen<M extends AbstractAlchemistryMenu> extends AbstractContainerScreen<M> {
+
+    protected final Button lockButton;
+    protected final Button unlockButton;
+
+    protected final Button pauseButton;
+    protected final Button resumeButton;
 
     public AbstractAlchemistryScreen(M pMenu, Inventory pPlayerInventory, Component pTitle) {
         super(pMenu, pPlayerInventory, pTitle);
+
+        lockButton = new Button(0, 0, 80, 20, new TranslatableComponent("alchemistry.container.lock_recipe"), handleLock());
+        unlockButton = new Button(0, 0, 80, 20, new TranslatableComponent("alchemistry.container.unlock_recipe"), handleLock());
+        pauseButton = new Button(0, 0, 80, 20, new TranslatableComponent("alchemistry.container.pause"), handlePause());
+        resumeButton = new Button(0, 0, 80, 20, new TranslatableComponent("alchemistry.container.resume"), handlePause());
+    }
+
+    @Override
+    public void render(PoseStack pPoseStack, int pMouseX, int pMouseY, float pPartialTick) {
+        renderBackground(pPoseStack);
+        renderBg(pPoseStack, pPartialTick, pMouseX, pMouseY);
+        super.render(pPoseStack, pMouseX, pMouseY, pPartialTick);
+        renderWidgets();
     }
 
     public void drawFluidTank(FluidDisplayData pData, int pTextureX, int pTextureY) {
@@ -170,5 +193,35 @@ public abstract class AbstractAlchemistryScreen<M extends AbstractContainerMenu>
             }
             addRenderableWidget(pWidget);
         }
+    }
+
+    public void renderWidgets() {
+        renderables.clear();
+        if (menu.getBlockEntity().isRecipeLocked()) {
+            renderWidget(unlockButton, leftPos - 84, topPos);
+        } else {
+            renderWidget(lockButton, leftPos - 84, topPos);
+        }
+        if (menu.getBlockEntity().isProcessingPaused()) {
+            renderWidget(resumeButton, leftPos - 84, topPos + 24);
+        } else {
+            renderWidget(pauseButton, leftPos - 84, topPos + 24);
+        }
+    }
+
+    private Button.OnPress handleLock() {
+        return pButton -> {
+            boolean lockState = menu.getBlockEntity().isRecipeLocked();
+            boolean pausedState = menu.getBlockEntity().isProcessingPaused();
+            AlchemistryPacketHandler.INSTANCE.sendToServer(new ProcessingButtonPacket(menu.getBlockEntity().getBlockPos(), !lockState, pausedState));
+        };
+    }
+
+    private Button.OnPress handlePause() {
+        return pButton -> {
+            boolean lockState = menu.getBlockEntity().isRecipeLocked();
+            boolean pausedState = menu.getBlockEntity().isProcessingPaused();
+            AlchemistryPacketHandler.INSTANCE.sendToServer(new ProcessingButtonPacket(menu.getBlockEntity().getBlockPos(), lockState, !pausedState));
+        };
     }
 }

--- a/src/main/java/com/smashingmods/alchemistry/common/block/atomizer/AtomizerBlockEntity.java
+++ b/src/main/java/com/smashingmods/alchemistry/common/block/atomizer/AtomizerBlockEntity.java
@@ -1,7 +1,7 @@
 package com.smashingmods.alchemistry.common.block.atomizer;
 
 import com.smashingmods.alchemistry.Config;
-import com.smashingmods.alchemistry.api.blockentity.*;
+import com.smashingmods.alchemistry.api.blockentity.AbstractFluidBlockEntity;
 import com.smashingmods.alchemistry.api.blockentity.handler.CustomEnergyStorage;
 import com.smashingmods.alchemistry.api.blockentity.handler.CustomFluidStorage;
 import com.smashingmods.alchemistry.api.blockentity.handler.CustomItemStackHandler;
@@ -64,10 +64,15 @@ public class AtomizerBlockEntity extends AbstractFluidBlockEntity {
 
     public void updateRecipe() {
         if (level != null && !level.isClientSide()) {
-            if (!getFluidStorage().isEmpty() && (currentRecipe == null || getItemHandler().getStackInSlot(0).isEmpty() || ItemStack.isSameItemSameTags(currentRecipe.getOutput(), getItemHandler().getStackInSlot(0)))) {
-                currentRecipe = RecipeRegistry.getRecipesByType(RecipeRegistry.ATOMIZER_TYPE, level).stream()
-                        .filter(recipe -> recipe.getInput().getFluid() == getFluidStorage().getFluidStack().getFluid()).findFirst().orElse(null);
-            }
+            RecipeRegistry.getRecipesByType(RecipeRegistry.ATOMIZER_TYPE, level).stream()
+                    .filter(recipe -> recipe.getInput().getFluid().equals(getFluidStorage().getFluidStack().getFluid()))
+                    .findFirst()
+                    .ifPresent(recipe -> {
+                        if (currentRecipe == null || !currentRecipe.equals(recipe)) {
+                            setProgress(0);
+                            currentRecipe = recipe;
+                        }
+                    });
         }
     }
 
@@ -75,7 +80,7 @@ public class AtomizerBlockEntity extends AbstractFluidBlockEntity {
         if (currentRecipe != null) {
             return getEnergyHandler().getEnergyStored() >= Config.Common.atomizerEnergyPerTick.get()
                     && getFluidStorage().getFluidAmount() >= currentRecipe.getInput().getAmount()
-                    && (ItemStack.isSameItemSameTags(getItemHandler().getStackInSlot(0), currentRecipe.getOutput())) || getItemHandler().getStackInSlot(0).isEmpty()
+                    && ((ItemStack.isSameItemSameTags(getItemHandler().getStackInSlot(0), currentRecipe.getOutput())) || getItemHandler().getStackInSlot(0).isEmpty())
                     && (getItemHandler().getStackInSlot(0).getCount() + currentRecipe.getOutput().getCount()) <= currentRecipe.getOutput().getMaxStackSize();
         } else {
             return false;
@@ -95,7 +100,7 @@ public class AtomizerBlockEntity extends AbstractFluidBlockEntity {
     }
 
     @Override
-    public <T extends Recipe<Inventory>> void setRecipe(T pRecipe) {
+    public <T extends Recipe<Inventory>> void setRecipe(@Nullable T pRecipe) {
         currentRecipe = (AtomizerRecipe) pRecipe;
     }
 

--- a/src/main/java/com/smashingmods/alchemistry/common/block/atomizer/AtomizerScreen.java
+++ b/src/main/java/com/smashingmods/alchemistry/common/block/atomizer/AtomizerScreen.java
@@ -9,6 +9,7 @@ import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.TranslatableComponent;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.entity.player.Inventory;
+
 import java.util.ArrayList;
 import java.util.List;
 
@@ -25,8 +26,6 @@ public class AtomizerScreen extends AbstractAlchemistryScreen<AtomizerMenu> {
 
     @Override
     public void render(PoseStack pPoseStack, int pMouseX, int pMouseY, float pPartialTick) {
-        renderBackground(pPoseStack);
-        renderBg(pPoseStack, pPartialTick, pMouseX, pMouseY);
         super.render(pPoseStack, pMouseX, pMouseY, pPartialTick);
 
         renderDisplayData(displayData, pPoseStack, leftPos, topPos);

--- a/src/main/java/com/smashingmods/alchemistry/common/block/combiner/CombinerBlockEntity.java
+++ b/src/main/java/com/smashingmods/alchemistry/common/block/combiner/CombinerBlockEntity.java
@@ -1,7 +1,7 @@
 package com.smashingmods.alchemistry.common.block.combiner;
 
 import com.smashingmods.alchemistry.Config;
-import com.smashingmods.alchemistry.api.blockentity.*;
+import com.smashingmods.alchemistry.api.blockentity.AbstractInventoryBlockEntity;
 import com.smashingmods.alchemistry.api.blockentity.handler.CustomEnergyStorage;
 import com.smashingmods.alchemistry.api.blockentity.handler.CustomItemStackHandler;
 import com.smashingmods.alchemistry.common.recipe.combiner.CombinerRecipe;
@@ -18,9 +18,9 @@ import net.minecraft.world.item.crafting.Recipe;
 import net.minecraft.world.level.block.state.BlockState;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Optional;
 
 public class CombinerBlockEntity extends AbstractInventoryBlockEntity {
 
@@ -66,8 +66,17 @@ public class CombinerBlockEntity extends AbstractInventoryBlockEntity {
     @Override
     public void updateRecipe() {
         if (level != null && !level.isClientSide()) {
-            Optional<CombinerRecipe> combinerRecipe = RecipeRegistry.getRecipesByType(RecipeRegistry.COMBINER_TYPE, level).stream().filter(recipe -> recipe.matchInputs(getInputHandler())).findFirst();
-            combinerRecipe.ifPresent(this::setRecipe);
+            if (currentRecipe == null) {
+                RecipeRegistry.getRecipesByType(RecipeRegistry.COMBINER_TYPE, level).stream()
+                        .filter(recipe -> recipe.matchInputs(getInputHandler()))
+                        .findFirst()
+                        .ifPresent(recipe -> {
+                            if (currentRecipe == null || !currentRecipe.equals(recipe)) {
+                                setProgress(0);
+                                setRecipe(recipe);
+                            }
+                        });
+            }
         }
     }
 
@@ -99,7 +108,7 @@ public class CombinerBlockEntity extends AbstractInventoryBlockEntity {
     }
 
     @Override
-    public <T extends Recipe<Inventory>> void setRecipe(T pRecipe) {
+    public <T extends Recipe<Inventory>> void setRecipe(@Nullable T pRecipe) {
         currentRecipe = (CombinerRecipe) pRecipe;
     }
 

--- a/src/main/java/com/smashingmods/alchemistry/common/block/combiner/CombinerMenu.java
+++ b/src/main/java/com/smashingmods/alchemistry/common/block/combiner/CombinerMenu.java
@@ -11,10 +11,14 @@ import com.smashingmods.alchemistry.registry.RecipeRegistry;
 import net.minecraft.network.FriendlyByteBuf;
 import net.minecraft.world.entity.player.Inventory;
 import net.minecraft.world.entity.player.Player;
-import net.minecraft.world.inventory.*;
+import net.minecraft.world.inventory.ContainerData;
+import net.minecraft.world.inventory.ContainerLevelAccess;
+import net.minecraft.world.inventory.SimpleContainerData;
+import net.minecraft.world.inventory.Slot;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraftforge.items.SlotItemHandler;
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
@@ -60,12 +64,14 @@ public class CombinerMenu extends AbstractAlchemistryMenu {
     @Override
     public boolean clickMenuButton(Player pPlayer, int pId) {
         if(pPlayer.level.isClientSide()) {
-            if (this.isValidRecipeIndex(pId)) {
-                int recipeIndex = blockEntity.getRecipes().indexOf(displayedRecipes.get(pId));
-                CombinerRecipe recipe = blockEntity.getRecipes().get(recipeIndex);
-                this.setSelectedRecipeIndex(pId);
-                this.blockEntity.setRecipe(recipe);
-                AlchemistryPacketHandler.INSTANCE.sendToServer(new CombinerRecipePacket(getBlockEntity().getBlockPos(), recipeIndex));
+            if (!getBlockEntity().isRecipeLocked()) {
+                if (this.isValidRecipeIndex(pId)) {
+                    int recipeIndex = blockEntity.getRecipes().indexOf(displayedRecipes.get(pId));
+                    CombinerRecipe recipe = blockEntity.getRecipes().get(recipeIndex);
+                    this.setSelectedRecipeIndex(pId);
+                    this.blockEntity.setRecipe(recipe);
+                    AlchemistryPacketHandler.INSTANCE.sendToServer(new CombinerRecipePacket(getBlockEntity().getBlockPos(), recipeIndex));
+                }
             }
         }
         return true;
@@ -111,6 +117,6 @@ public class CombinerMenu extends AbstractAlchemistryMenu {
         this.displayedRecipes.addAll(this.blockEntity.getRecipes().stream().filter(recipe -> {
             Objects.requireNonNull(recipe.getOutput().getItem().getRegistryName());
             return recipe.getOutput().getItem().getRegistryName().getPath().contains(pKeyword.toLowerCase().replace(" ", "_"));
-        }).collect(Collectors.toList()));
+        }).toList());
     }
 }

--- a/src/main/java/com/smashingmods/alchemistry/common/block/compactor/CompactorBlockEntity.java
+++ b/src/main/java/com/smashingmods/alchemistry/common/block/compactor/CompactorBlockEntity.java
@@ -1,7 +1,7 @@
 package com.smashingmods.alchemistry.common.block.compactor;
 
 import com.smashingmods.alchemistry.Config;
-import com.smashingmods.alchemistry.api.blockentity.*;
+import com.smashingmods.alchemistry.api.blockentity.AbstractInventoryBlockEntity;
 import com.smashingmods.alchemistry.api.blockentity.handler.CustomEnergyStorage;
 import com.smashingmods.alchemistry.api.blockentity.handler.CustomItemStackHandler;
 import com.smashingmods.alchemistry.common.network.AlchemistryPacketHandler;
@@ -18,11 +18,10 @@ import net.minecraft.world.inventory.ContainerData;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.crafting.Recipe;
 import net.minecraft.world.level.block.state.BlockState;
-import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import javax.annotation.Nonnull;
 import java.util.List;
-import java.util.stream.Collectors;
 
 public class CompactorBlockEntity extends AbstractInventoryBlockEntity {
 
@@ -68,14 +67,26 @@ public class CompactorBlockEntity extends AbstractInventoryBlockEntity {
                 if (target.isEmpty()) {
                     List<CompactorRecipe> recipes = RecipeRegistry.getRecipesByType(RecipeRegistry.COMPACTOR_TYPE, level).stream()
                             .filter(recipe -> ItemStack.isSameItemSameTags(getInputHandler().getStackInSlot(0), recipe.getInput()))
-                            .collect(Collectors.toList());
+                            .toList();
                     if (recipes.size() == 1) {
-                        currentRecipe = recipes.get(0);
+                        if (currentRecipe == null || !currentRecipe.equals(recipes.get(0))) {
+                            setProgress(0);
+                            currentRecipe = recipes.get(0);
+                        }
                     } else {
+                        setProgress(0);
                         currentRecipe = null;
                     }
                 } else {
-                    RecipeRegistry.getRecipesByType(RecipeRegistry.COMPACTOR_TYPE, level).stream().filter(recipe -> ItemStack.isSameItemSameTags(target, recipe.getOutput())).findFirst().ifPresent(recipe -> currentRecipe = recipe);
+                    RecipeRegistry.getRecipesByType(RecipeRegistry.COMPACTOR_TYPE, level).stream()
+                            .filter(recipe -> ItemStack.isSameItemSameTags(target, recipe.getOutput()))
+                            .findFirst()
+                            .ifPresent(recipe -> {
+                                if (!currentRecipe.equals(recipe)) {
+                                    setProgress(0);
+                                    currentRecipe = recipe;
+                                }
+                            });
                 }
             }
         }
@@ -150,15 +161,13 @@ public class CompactorBlockEntity extends AbstractInventoryBlockEntity {
             protected void onContentsChanged(int slot) {
                 if (level != null && !level.isClientSide()) {
                     if (slot == 1 && !getInputHandler().getStackInSlot(slot).isEmpty()) {
-                        RecipeRegistry.getRecipesByType(RecipeRegistry.COMPACTOR_TYPE, level).stream().filter(recipe -> ItemStack.isSameItemSameTags(initializeInputHandler().getStackInSlot(slot), recipe.getOutput())).findFirst().ifPresent(recipe -> {
-                            setRecipe(recipe);
-                        });
+                        RecipeRegistry.getRecipesByType(RecipeRegistry.COMPACTOR_TYPE, level).stream().filter(recipe -> ItemStack.isSameItemSameTags(initializeInputHandler().getStackInSlot(slot), recipe.getOutput())).findFirst().ifPresent(recipe -> setRecipe(recipe));
                     }
                 }
             }
 
             @Override
-            public boolean isItemValid(int slot, @NotNull ItemStack pItemStack) {
+            public boolean isItemValid(int slot, @Nonnull ItemStack pItemStack) {
                 if (slot == 1) {
                     target = new ItemStack(pItemStack.getItem(), 1);
                 }

--- a/src/main/java/com/smashingmods/alchemistry/common/block/compactor/CompactorScreen.java
+++ b/src/main/java/com/smashingmods/alchemistry/common/block/compactor/CompactorScreen.java
@@ -42,7 +42,6 @@ public class CompactorScreen extends AbstractAlchemistryScreen<CompactorMenu> {
         renderBg(pPoseStack, pPartialTick, pMouseX, pMouseY);
         super.render(pPoseStack, pMouseX, pMouseY, pPartialTick);
 
-        renderWidgets();
         renderDisplayData(displayData, pPoseStack, leftPos, topPos);
         renderDisplayTooltip(displayData, pPoseStack, leftPos, topPos, pMouseX, pMouseY);
 
@@ -64,8 +63,10 @@ public class CompactorScreen extends AbstractAlchemistryScreen<CompactorMenu> {
         drawString(pPoseStack, font, title, imageWidth / 2 - font.width(title) / 2, -10, 0xFFFFFFFF);
     }
 
-    private void renderWidgets() {
-        renderWidget(resetTargetButton, leftPos - 84, topPos);
+    @Override
+    public void renderWidgets() {
+        super.renderWidgets();
+        renderWidget(resetTargetButton, leftPos - 84, topPos + 48);
     }
 
     private void renderTarget(PoseStack pPoseStack, int pMouseX, int pMouseY) {
@@ -88,8 +89,6 @@ public class CompactorScreen extends AbstractAlchemistryScreen<CompactorMenu> {
     }
 
     private Button.OnPress handleResetTargetButton() {
-        return pButton -> {
-            AlchemistryPacketHandler.INSTANCE.sendToServer(new CompactorResetPacket(menu.getBlockEntity().getBlockPos()));
-        };
+        return pButton -> AlchemistryPacketHandler.INSTANCE.sendToServer(new CompactorResetPacket(menu.getBlockEntity().getBlockPos()));
     }
 }

--- a/src/main/java/com/smashingmods/alchemistry/common/block/dissolver/DissolverBlockEntity.java
+++ b/src/main/java/com/smashingmods/alchemistry/common/block/dissolver/DissolverBlockEntity.java
@@ -60,8 +60,8 @@ public class DissolverBlockEntity extends AbstractInventoryBlockEntity {
     @Override
     public void tick() {
         if (level != null && !level.isClientSide()) {
-            if (!this.getPaused()) {
-                if (!this.getRecipeLocked()) {
+            if (!isProcessingPaused()) {
+                if (!isRecipeLocked()) {
                     updateRecipe();
                 }
                 if (canProcessRecipe()) {
@@ -75,10 +75,15 @@ public class DissolverBlockEntity extends AbstractInventoryBlockEntity {
     @Override
     public void updateRecipe() {
         if (level != null && !level.isClientSide()) {
-            currentRecipe = RecipeRegistry.getRecipesByType(RecipeRegistry.DISSOLVER_TYPE, level).stream()
+            RecipeRegistry.getRecipesByType(RecipeRegistry.DISSOLVER_TYPE, level).stream()
                 .filter(recipe -> recipe.matches(getInputHandler().getStackInSlot(0)))
                 .findAny()
-                .orElse(null);
+                .ifPresent(recipe -> {
+                    if (currentRecipe == null || !currentRecipe.equals(recipe)) {
+                        setProgress(0);
+                        currentRecipe = recipe;
+                    }
+            });
         }
     }
 

--- a/src/main/java/com/smashingmods/alchemistry/common/block/dissolver/DissolverScreen.java
+++ b/src/main/java/com/smashingmods/alchemistry/common/block/dissolver/DissolverScreen.java
@@ -9,6 +9,7 @@ import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.TranslatableComponent;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.entity.player.Inventory;
+
 import java.util.ArrayList;
 import java.util.List;
 
@@ -25,8 +26,6 @@ public class DissolverScreen extends AbstractAlchemistryScreen<DissolverMenu> {
 
     @Override
     public void render(PoseStack pPoseStack, int pMouseX, int pMouseY, float pPartialTick) {
-        renderBackground(pPoseStack);
-        renderBg(pPoseStack, pPartialTick, pMouseX, pMouseY);
         super.render(pPoseStack, pMouseX, pMouseY, pPartialTick);
 
         renderDisplayData(displayData, pPoseStack, this.leftPos, this.topPos);

--- a/src/main/java/com/smashingmods/alchemistry/common/block/fission/FissionControllerScreen.java
+++ b/src/main/java/com/smashingmods/alchemistry/common/block/fission/FissionControllerScreen.java
@@ -9,6 +9,7 @@ import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.TranslatableComponent;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.entity.player.Inventory;
+
 import java.util.ArrayList;
 import java.util.List;
 
@@ -25,13 +26,11 @@ public class FissionControllerScreen extends AbstractAlchemistryScreen<FissionCo
 
     @Override
     public void render(PoseStack pPoseStack, int pMouseX, int pMouseY, float pPartialTick) {
-        this.renderBackground(pPoseStack);
-        this.renderBg(pPoseStack, pPartialTick, pMouseX, pMouseY);
         super.render(pPoseStack, pMouseX, pMouseY, pPartialTick);
 
-        this.renderDisplayData(displayData, pPoseStack, leftPos, topPos);
-        this.renderDisplayTooltip(displayData, pPoseStack, leftPos, topPos, pMouseX, pMouseY);
-        this.renderTooltip(pPoseStack, pMouseX, pMouseY);
+        renderDisplayData(displayData, pPoseStack, leftPos, topPos);
+        renderDisplayTooltip(displayData, pPoseStack, leftPos, topPos, pMouseX, pMouseY);
+        renderTooltip(pPoseStack, pMouseX, pMouseY);
     }
 
     @Override
@@ -39,7 +38,7 @@ public class FissionControllerScreen extends AbstractAlchemistryScreen<FissionCo
         RenderSystem.setShader(GameRenderer::getPositionTexShader);
         RenderSystem.setShaderColor(1.0f, 1.0f, 1.0f, 1.0f);
         RenderSystem.setShaderTexture(0, new ResourceLocation(Alchemistry.MODID, "textures/gui/fission_gui.png"));
-        this.blit(pPoseStack, leftPos, topPos, 0, 0, imageWidth, imageHeight);
+        blit(pPoseStack, leftPos, topPos, 0, 0, imageWidth, imageHeight);
     }
 
     @Override

--- a/src/main/java/com/smashingmods/alchemistry/common/block/fusion/FusionControllerScreen.java
+++ b/src/main/java/com/smashingmods/alchemistry/common/block/fusion/FusionControllerScreen.java
@@ -9,6 +9,7 @@ import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.TranslatableComponent;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.entity.player.Inventory;
+
 import java.util.ArrayList;
 import java.util.List;
 
@@ -25,13 +26,11 @@ public class FusionControllerScreen extends AbstractAlchemistryScreen<FusionCont
 
     @Override
     public void render(PoseStack pPoseStack, int pMouseX, int pMouseY, float pPartialTick) {
-        this.renderBackground(pPoseStack);
-        this.renderBg(pPoseStack, pPartialTick, pMouseX, pMouseY);
         super.render(pPoseStack, pMouseX, pMouseY, pPartialTick);
 
-        this.renderDisplayData(displayData, pPoseStack, leftPos, topPos);
-        this.renderDisplayTooltip(displayData, pPoseStack, leftPos, topPos, pMouseX, pMouseY);
-        this.renderTooltip(pPoseStack, pMouseX, pMouseY);
+        renderDisplayData(displayData, pPoseStack, leftPos, topPos);
+        renderDisplayTooltip(displayData, pPoseStack, leftPos, topPos, pMouseX, pMouseY);
+        renderTooltip(pPoseStack, pMouseX, pMouseY);
     }
 
     @Override

--- a/src/main/java/com/smashingmods/alchemistry/common/block/liquifier/LiquifierBlockEntity.java
+++ b/src/main/java/com/smashingmods/alchemistry/common/block/liquifier/LiquifierBlockEntity.java
@@ -1,7 +1,7 @@
 package com.smashingmods.alchemistry.common.block.liquifier;
 
 import com.smashingmods.alchemistry.Config;
-import com.smashingmods.alchemistry.api.blockentity.*;
+import com.smashingmods.alchemistry.api.blockentity.AbstractFluidBlockEntity;
 import com.smashingmods.alchemistry.api.blockentity.handler.CustomEnergyStorage;
 import com.smashingmods.alchemistry.api.blockentity.handler.CustomFluidStorage;
 import com.smashingmods.alchemistry.api.blockentity.handler.CustomItemStackHandler;
@@ -65,12 +65,15 @@ public class LiquifierBlockEntity extends AbstractFluidBlockEntity {
     @Override
     public void updateRecipe() {
         if (level != null && !level.isClientSide()) {
-            if (currentRecipe == null || ItemStack.isSameItemSameTags(currentRecipe.getInput(), getItemHandler().getStackInSlot(0))) {
-                currentRecipe = RecipeRegistry.getRecipesByType(RecipeRegistry.LIQUIFIER_TYPE, level).stream()
-                        .filter(recipe -> ItemStack.isSameItemSameTags(recipe.getInput(), getItemHandler().getStackInSlot(0)))
-                        .findFirst()
-                        .orElse(null);
-            }
+            RecipeRegistry.getRecipesByType(RecipeRegistry.LIQUIFIER_TYPE, level).stream()
+                    .filter(recipe -> ItemStack.isSameItemSameTags(recipe.getInput(), getItemHandler().getStackInSlot(0)))
+                    .findFirst()
+                    .ifPresent(recipe -> {
+                        if (currentRecipe == null || !currentRecipe.equals(recipe)) {
+                            setProgress(0);
+                            currentRecipe = recipe;
+                        }
+                    });
         }
     }
 
@@ -101,7 +104,7 @@ public class LiquifierBlockEntity extends AbstractFluidBlockEntity {
     }
 
     @Override
-    public <T extends Recipe<Inventory>> void setRecipe(T pRecipe) {
+    public <T extends Recipe<Inventory>> void setRecipe(@Nullable T pRecipe) {
         currentRecipe = (LiquifierRecipe) pRecipe;
     }
 

--- a/src/main/java/com/smashingmods/alchemistry/common/block/liquifier/LiquifierScreen.java
+++ b/src/main/java/com/smashingmods/alchemistry/common/block/liquifier/LiquifierScreen.java
@@ -9,6 +9,7 @@ import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.TranslatableComponent;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.entity.player.Inventory;
+
 import java.util.ArrayList;
 import java.util.List;
 
@@ -25,13 +26,11 @@ public class LiquifierScreen extends AbstractAlchemistryScreen<LiquifierMenu> {
 
     @Override
     public void render(PoseStack pPoseStack, int pMouseX, int pMouseY, float pPartialTick) {
-        this.renderBackground(pPoseStack);
-        this.renderBg(pPoseStack, pPartialTick, pMouseX, pMouseY);
         super.render(pPoseStack, pMouseX, pMouseY, pPartialTick);
 
-        this.renderDisplayData(displayData, pPoseStack, leftPos, topPos);
-        this.renderDisplayTooltip(displayData, pPoseStack, leftPos, topPos, pMouseX, pMouseY);
-        this.renderTooltip(pPoseStack, pMouseX, pMouseY);
+        renderDisplayData(displayData, pPoseStack, leftPos, topPos);
+        renderDisplayTooltip(displayData, pPoseStack, leftPos, topPos, pMouseX, pMouseY);
+        renderTooltip(pPoseStack, pMouseX, pMouseY);
     }
 
     @Override

--- a/src/main/java/com/smashingmods/alchemistry/common/network/AlchemistryPacketHandler.java
+++ b/src/main/java/com/smashingmods/alchemistry/common/network/AlchemistryPacketHandler.java
@@ -30,10 +30,10 @@ public class AlchemistryPacketHandler {
                 .consumer(BlockEntityPacket::handle)
                 .add();
 
-        INSTANCE.messageBuilder(CombinerButtonPacket.class, PACKET_ID++, NetworkDirection.PLAY_TO_SERVER)
-                .decoder(CombinerButtonPacket::new)
-                .encoder(CombinerButtonPacket::encode)
-                .consumer(CombinerButtonPacket::handle)
+        INSTANCE.messageBuilder(ProcessingButtonPacket.class, PACKET_ID++, NetworkDirection.PLAY_TO_SERVER)
+                .decoder(ProcessingButtonPacket::new)
+                .encoder(ProcessingButtonPacket::encode)
+                .consumer(ProcessingButtonPacket::handle)
                 .add();
 
         INSTANCE.messageBuilder(CompactorResetPacket.class, PACKET_ID++, NetworkDirection.PLAY_TO_SERVER)

--- a/src/main/java/com/smashingmods/alchemistry/common/network/CombinerRecipePacket.java
+++ b/src/main/java/com/smashingmods/alchemistry/common/network/CombinerRecipePacket.java
@@ -1,6 +1,7 @@
 package com.smashingmods.alchemistry.common.network;
 
 import com.smashingmods.alchemistry.common.block.combiner.CombinerBlockEntity;
+import com.smashingmods.alchemistry.common.recipe.combiner.CombinerRecipe;
 import net.minecraft.core.BlockPos;
 import net.minecraft.network.FriendlyByteBuf;
 import net.minecraft.world.entity.player.Player;
@@ -35,7 +36,12 @@ public class CombinerRecipePacket {
             Objects.requireNonNull(player);
             CombinerBlockEntity blockEntity = (CombinerBlockEntity) player.level.getBlockEntity(pPacket.blockPos);
             Objects.requireNonNull(blockEntity);
-            blockEntity.setRecipe(blockEntity.getRecipes().get(pPacket.recipeIndex));
+            CombinerRecipe newRecipe = blockEntity.getRecipes().get(pPacket.recipeIndex);
+            //noinspection ConstantConditions
+            if (blockEntity.getRecipe() == null || !blockEntity.getRecipe().equals(newRecipe)) {
+                blockEntity.setProgress(0);
+                blockEntity.setRecipe(newRecipe);
+            }
         });
         pContext.get().setPacketHandled(true);
     }

--- a/src/main/java/com/smashingmods/alchemistry/common/network/ProcessingButtonPacket.java
+++ b/src/main/java/com/smashingmods/alchemistry/common/network/ProcessingButtonPacket.java
@@ -1,26 +1,27 @@
 package com.smashingmods.alchemistry.common.network;
 
-import com.smashingmods.alchemistry.common.block.combiner.CombinerBlockEntity;
+import com.smashingmods.alchemistry.api.blockentity.AbstractProcessingBlockEntity;
 import net.minecraft.core.BlockPos;
 import net.minecraft.network.FriendlyByteBuf;
 import net.minecraft.world.entity.player.Player;
 import net.minecraftforge.network.NetworkEvent;
+
 import java.util.Objects;
 import java.util.function.Supplier;
 
-public class CombinerButtonPacket {
+public class ProcessingButtonPacket {
 
     private final BlockPos blockPos;
     private final boolean lock;
     private final boolean pause;
 
-    public CombinerButtonPacket(BlockPos pBlockPos, boolean pLock, boolean pPause) {
+    public ProcessingButtonPacket(BlockPos pBlockPos, boolean pLock, boolean pPause) {
         this.blockPos = pBlockPos;
         this.lock = pLock;
         this.pause = pPause;
     }
 
-    public CombinerButtonPacket(FriendlyByteBuf pBuffer) {
+    public ProcessingButtonPacket(FriendlyByteBuf pBuffer) {
         this.blockPos = pBuffer.readBlockPos();
         this.lock = pBuffer.readBoolean();
         this.pause = pBuffer.readBoolean();
@@ -32,12 +33,12 @@ public class CombinerButtonPacket {
         pBuffer.writeBoolean(pause);
     }
 
-    public static void handle(final CombinerButtonPacket pPacket, Supplier<NetworkEvent.Context> pContext) {
+    public static void handle(final ProcessingButtonPacket pPacket, Supplier<NetworkEvent.Context> pContext) {
         pContext.get().enqueueWork(() -> {
             Player player = pContext.get().getSender();
             Objects.requireNonNull(player);
 
-            CombinerBlockEntity blockEntity = (CombinerBlockEntity) player.level.getBlockEntity(pPacket.blockPos);
+            AbstractProcessingBlockEntity blockEntity = (AbstractProcessingBlockEntity) player.level.getBlockEntity(pPacket.blockPos);
 
             Objects.requireNonNull(blockEntity);
 

--- a/src/main/java/com/smashingmods/alchemistry/common/recipe/combiner/CombinerRecipe.java
+++ b/src/main/java/com/smashingmods/alchemistry/common/recipe/combiner/CombinerRecipe.java
@@ -9,8 +9,10 @@ import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.crafting.RecipeSerializer;
 import net.minecraft.world.item.crafting.RecipeType;
 import org.jetbrains.annotations.NotNull;
-import java.util.*;
-import java.util.stream.Collectors;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
 
 public class CombinerRecipe extends AbstractAlchemistryRecipe implements Comparable<CombinerRecipe> {
 
@@ -69,8 +71,8 @@ public class CombinerRecipe extends AbstractAlchemistryRecipe implements Compara
     public boolean matchInputs(List<ItemStack> pStacks) {
         int matchingStacks = 0;
 
-        List<ItemStack> handlerStacks = pStacks.stream().filter(itemStack -> !itemStack.isEmpty()).collect(Collectors.toList());
-        List<ItemStack> recipeStacks = input.stream().filter(itemStack -> !itemStack.isEmpty()).collect(Collectors.toList());
+        List<ItemStack> handlerStacks = pStacks.stream().filter(itemStack -> !itemStack.isEmpty()).toList();
+        List<ItemStack> recipeStacks = input.stream().filter(itemStack -> !itemStack.isEmpty()).toList();
 
         if (recipeStacks.size() == handlerStacks.size()) {
             for (ItemStack recipeStack : recipeStacks) {


### PR DESCRIPTION
Set processing progress to 0 if recipe changes for all machines.
Improve how recipes are set when updating the recipe. Should perform better and return less nulls.
Add recipe lock/unlock and processing pause/unpause buttons to all machines.
Move widget rendering to AbstractAlchemistryScreen since they are now all rendering widgets.
Fix Atomizer continuing to process without an input because I missed a parenthesis.