### PR TITLE
Fix the Combiner not accepting items it already has any amount of

### DIFF
--- a/src/main/java/com/smashingmods/alchemistry/common/block/fusion/FusionControllerBlockEntity.java
+++ b/src/main/java/com/smashingmods/alchemistry/common/block/fusion/FusionControllerBlockEntity.java
@@ -207,7 +207,7 @@ public class FusionControllerBlockEntity extends AbstractReactorBlockEntity {
                     };
 
                     RecipeRegistry.getFusionRecipe(recipePredicate, level).ifPresent(recipe -> {
-                        if (!currentRecipe.equals(recipe)) {
+                        if (currentRecipe == null || !currentRecipe.equals(recipe)) {
                             setProgress(0);
                             setRecipe(recipe);
                             autoBalance();


### PR DESCRIPTION
This is a partial fix for the problem, as explained in Discord. If a pipe tries to insert more of an item than can be accepted, then instead of accepting only the amount that can be accepted and rejecting the extra, the insertion attempt will be rejected completely.