### PR TITLE
Fix a NullPointerException caused when connecting a Refined Storage exporter to a fusion reactor

### DIFF
--- a/src/main/java/com/smashingmods/alchemistry/common/block/fusion/FusionControllerBlockEntity.java
+++ b/src/main/java/com/smashingmods/alchemistry/common/block/fusion/FusionControllerBlockEntity.java
@@ -207,7 +207,7 @@ public class FusionControllerBlockEntity extends AbstractReactorBlockEntity {
                     };
 
                     RecipeRegistry.getFusionRecipe(recipePredicate, level).ifPresent(recipe -> {
-                        if (!currentRecipe.equals(recipe)) {
+                        if (currentRecipe == null || !currentRecipe.equals(recipe)) {
                             setProgress(0);
                             setRecipe(recipe);
                             autoBalance();


### PR DESCRIPTION
Sometimes `currentRecipe` is null during a call to `currentRecipe.equals`, causing an NPE.