### PR TITLE
Add a reload listener to `RecipeRegistry`.

### DIFF
--- a/src/main/java/com/smashingmods/alchemistry/Alchemistry.java
+++ b/src/main/java/com/smashingmods/alchemistry/Alchemistry.java
@@ -10,8 +10,10 @@ import com.smashingmods.alchemistry.common.block.liquifier.LiquifierScreen;
 import com.smashingmods.alchemistry.common.network.PacketHandler;
 import com.smashingmods.alchemistry.datagen.DataGenerators;
 import com.smashingmods.alchemistry.registry.MenuRegistry;
+import com.smashingmods.alchemistry.registry.RecipeRegistry;
 import com.smashingmods.alchemistry.registry.Registry;
 import net.minecraft.client.gui.screens.MenuScreens;
+import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.eventbus.api.IEventBus;
 import net.minecraftforge.fml.ModLoadingContext;
 import net.minecraftforge.fml.common.Mod;
@@ -37,6 +39,9 @@ public class Alchemistry {
         ModLoadingContext.get().registerConfig(ModConfig.Type.COMMON, Config.COMMON_SPEC);
         Config.loadConfig(Config.COMMON_SPEC, FMLPaths.CONFIGDIR.get().resolve("alchemistry-common.toml"));
         Registry.register();
+
+        // Make sure that `/reload` and world loading wipe the machine recipe cache.
+        MinecraftForge.EVENT_BUS.addListener(RecipeRegistry::postReload);
     }
 
     public void clientSetupEvent(final FMLClientSetupEvent event) {

--- a/src/main/java/com/smashingmods/alchemistry/registry/RecipeRegistry.java
+++ b/src/main/java/com/smashingmods/alchemistry/registry/RecipeRegistry.java
@@ -1,7 +1,5 @@
 package com.smashingmods.alchemistry.registry;
 
-import com.google.gson.GsonBuilder;
-import com.google.gson.JsonElement;
 import com.smashingmods.alchemistry.common.recipe.atomizer.AtomizerRecipe;
 import com.smashingmods.alchemistry.common.recipe.atomizer.AtomizerRecipeSerializer;
 import com.smashingmods.alchemistry.common.recipe.combiner.CombinerRecipe;
@@ -18,35 +16,25 @@ import com.smashingmods.alchemistry.common.recipe.liquifier.LiquifierRecipe;
 import com.smashingmods.alchemistry.common.recipe.liquifier.LiquifierRecipeSerializer;
 import com.smashingmods.alchemylib.api.recipe.AbstractProcessingRecipe;
 import net.minecraft.resources.ResourceLocation;
-import net.minecraft.server.ReloadableServerResources;
-import net.minecraft.server.packs.FolderPackResources;
-import net.minecraft.server.packs.PackResources;
-import net.minecraft.server.packs.PackType;
-import net.minecraft.server.packs.repository.Pack;
-import net.minecraft.server.packs.resources.*;
+import net.minecraft.server.packs.resources.ResourceManager;
+import net.minecraft.server.packs.resources.SimplePreparableReloadListener;
 import net.minecraft.util.profiling.ProfilerFiller;
 import net.minecraft.world.item.crafting.RecipeSerializer;
 import net.minecraft.world.item.crafting.RecipeType;
 import net.minecraft.world.level.Level;
 import net.minecraftforge.event.AddReloadListenerEvent;
 import net.minecraftforge.eventbus.api.IEventBus;
-import net.minecraftforge.eventbus.api.SubscribeEvent;
-import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.registries.DeferredRegister;
 import net.minecraftforge.registries.ForgeRegistries;
 import net.minecraftforge.registries.RegistryObject;
 
-import javax.json.JsonObject;
 import java.util.LinkedHashMap;
 import java.util.LinkedList;
 import java.util.Map;
 import java.util.Optional;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.Executor;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
-import static com.smashingmods.alchemistry.Alchemistry.LOGGER;
 import static com.smashingmods.alchemistry.Alchemistry.MODID;
 
 public class RecipeRegistry {
@@ -119,8 +107,8 @@ public class RecipeRegistry {
 
             // Runs on main thread; does the actual cache invalidation.
             @Override
-            protected void apply(Boolean shouldClear, ResourceManager pResourceManager, ProfilerFiller pProfiler) {
-                if (shouldClear) {
+            protected void apply(Boolean pShouldClear, ResourceManager pResourceManager, ProfilerFiller pProfiler) {
+                if (pShouldClear) {
                     recipeTypeMap.clear();
                     recipeGroupMap.clear();
                 }

--- a/src/main/java/com/smashingmods/alchemistry/registry/RecipeRegistry.java
+++ b/src/main/java/com/smashingmods/alchemistry/registry/RecipeRegistry.java
@@ -96,12 +96,12 @@ public class RecipeRegistry {
     }
 
     /**
-     * After reloading resources, clear the internal {@link RecipeRegistry#recipeTypeMap recipeTypeMap} and
+     * Attach a ReloadListener that clears the internal {@link RecipeRegistry#recipeTypeMap recipeTypeMap} and
      * {@link RecipeRegistry#recipeGroupMap recipeGroupMap} so that data pack reloading takes effect immediately.
      * @implNote This event handler just clears the internal maps, but a better version might update them in-place.
      *           That said, datapack reloads don't actually occur that often in regular play, so there is little point
      *           over-engineering this.
-     * @param event the AddReloadListener event. Unused.
+     * @param event the AddReloadListener event.
      */
     public static void postReload(final AddReloadListenerEvent event) {
         event.addListener(new SimplePreparableReloadListener<Boolean>() {


### PR DESCRIPTION
# What This PR Does:

This PR fixes an issue where machines wouldn't respect newly-added data pack recipes until Minecraft was restarted.

## Expected Behaviour:
- Data pack author creates a valid datapack
- Data pack author runs `/reload`
- Machines follow new recipes.

## Actual Behaviour:
- Data pack author creates a valid datapack
- Data pack author runs `/reload`
- Machines hang on to the old recipes, as if the `/reload` never happened.
- Data pack author is sad, and has to restart the game to see their changes in effect.

# What was the issue?

`RecipeRegistry`'s internal `recipeTypeMap` and `recipeGroupMap` fields did not get updated on data pack reload. Thus, even though the game's `RecipeManager` knew about newly-added recipes, `RecipeRegistry`'s family of helper methods hit the old cached methods in the internal `Map`s.

# How does the fix work?

To fix the issue, I register a `SimplePreparableReloadListener` that clears both internal `Map`s when data packs are reloaded. 


# Limitations and Future Work

The code isn't very sophisticated, and clears both maps even if nothing that changed would invalidate the cache. I tried to write a reload listener that would only alter the maps the minimum amount that it had to, but I couldn't come up with anything simple. So, it's arguably bad code.

However, the cache would only be cleared whenever someone ran `/reload` or loaded into a new world – both would be okay times to clear the cache. The people most affected by the arguably-unnecessary cache invalidations would be pack makers, who I don't imagine are too concerned with a little bit of performance drop when they reload data packs.

It's easy to extend the existing reload listener to prevent unnecessary invalidation, so someone could try in the future.
