### PR TITLE
Null guard recipe check in FusionControllerBlockEntity

### DIFF
--- a/src/main/java/com/smashingmods/alchemistry/common/block/fusion/FusionControllerBlockEntity.java
+++ b/src/main/java/com/smashingmods/alchemistry/common/block/fusion/FusionControllerBlockEntity.java
@@ -207,7 +207,7 @@ public class FusionControllerBlockEntity extends AbstractReactorBlockEntity {
                     };
 
                     RecipeRegistry.getFusionRecipe(recipePredicate, level).ifPresent(recipe -> {
-                        if (!currentRecipe.equals(recipe)) {
+                        if (currentRecipe == null || !currentRecipe.equals(recipe)) {
                             setProgress(0);
                             setRecipe(recipe);
                             autoBalance();


### PR DESCRIPTION
Prevents instant crashing on loading world. Can't call .equals check from a null object.