### PR TITLE
Fix mekanism transmitters not being connected after a restart

### DIFF
--- a/src/main/java/com/smashingmods/alchemistry/common/block/reactor/AbstractReactorBlockEntity.java
+++ b/src/main/java/com/smashingmods/alchemistry/common/block/reactor/AbstractReactorBlockEntity.java
@@ -2,6 +2,7 @@ package com.smashingmods.alchemistry.common.block.reactor;
 
 import com.mojang.math.Vector3f;
 import com.smashingmods.alchemistry.Alchemistry;
+import com.smashingmods.alchemistry.registry.BlockRegistry;
 import com.smashingmods.alchemylib.api.blockentity.power.PowerState;
 import com.smashingmods.alchemylib.api.blockentity.power.PowerStateProperty;
 import com.smashingmods.alchemylib.api.blockentity.processing.AbstractInventoryBlockEntity;
@@ -120,11 +121,10 @@ public abstract class AbstractReactorBlockEntity extends AbstractInventoryBlockE
                         .filter(blockPos -> level.getBlockEntity(blockPos) instanceof ReactorEnergyBlockEntity)
                         .findFirst()
                         .ifPresent(blockPos -> {
-                            BlockState energyState = level.getBlockState(blockPos);
-                            level.setBlockAndUpdate(blockPos, Blocks.AIR.defaultBlockState());
-                            level.setBlockAndUpdate(blockPos, energyState);
                             setEnergyFound(true);
                             reactorEnergyBlockEntity = (ReactorEnergyBlockEntity) level.getBlockEntity(blockPos);
+                            reactorEnergyBlockEntity.setController(this);
+                            level.updateNeighborsAt(blockPos, BlockRegistry.REACTOR_ENERGY.get());
                         });
             } else {
                 reactorEnergyBlockEntity.setController(this);
@@ -135,11 +135,10 @@ public abstract class AbstractReactorBlockEntity extends AbstractInventoryBlockE
                         .filter(blockPos -> level.getBlockEntity(blockPos) instanceof ReactorInputBlockEntity)
                         .findFirst()
                         .ifPresent(blockPos -> {
-                            BlockState inputState = level.getBlockState(blockPos);
-                            level.setBlock(blockPos, Blocks.AIR.defaultBlockState(), 7);
-                            level.setBlock(blockPos, inputState, 7);
                             inputFound = true;
                             reactorInputBlockEntity = (ReactorInputBlockEntity) level.getBlockEntity(blockPos);
+                            reactorInputBlockEntity.setController(this);
+                            level.updateNeighborsAt(blockPos, BlockRegistry.REACTOR_INPUT.get());
                         });
             } else {
                 reactorInputBlockEntity.setController(this);
@@ -151,11 +150,10 @@ public abstract class AbstractReactorBlockEntity extends AbstractInventoryBlockE
                         .filter(blockPos -> level.getBlockEntity(blockPos) instanceof ReactorOutputBlockEntity)
                         .findFirst()
                         .ifPresent(blockPos -> {
-                            BlockState outputState = level.getBlockState(blockPos);
-                            level.setBlock(blockPos, Blocks.AIR.defaultBlockState(), 7);
-                            level.setBlock(blockPos, outputState, 7);
                             outputFound = true;
                             reactorOutputBlockEntity = (ReactorOutputBlockEntity) level.getBlockEntity(blockPos);
+                            reactorOutputBlockEntity.setController(this);
+                            level.updateNeighborsAt(blockPos, BlockRegistry.REACTOR_OUTPUT.get());
                         });
             } else {
                 reactorOutputBlockEntity.setController(this);

--- a/src/main/java/com/smashingmods/alchemistry/common/block/reactor/ReactorEnergyBlockEntity.java
+++ b/src/main/java/com/smashingmods/alchemistry/common/block/reactor/ReactorEnergyBlockEntity.java
@@ -29,6 +29,10 @@ public class ReactorEnergyBlockEntity extends BlockEntity {
     }
 
     public void setController(@Nullable AbstractReactorBlockEntity pController) {
+        if (this.controller == pController) {
+            // No need to create superfluous LazyOptional instances
+            return;
+        }
         this.controller = pController;
         //noinspection ConstantConditions
         this.lazyEnergyHandler = LazyOptional.of(() -> controller.getEnergyHandler());

--- a/src/main/java/com/smashingmods/alchemistry/common/block/reactor/ReactorInputBlockEntity.java
+++ b/src/main/java/com/smashingmods/alchemistry/common/block/reactor/ReactorInputBlockEntity.java
@@ -29,6 +29,10 @@ public class ReactorInputBlockEntity extends BlockEntity {
     }
 
     public void setController(@Nullable AbstractReactorBlockEntity pController) {
+        if (this.controller == pController) {
+            // No need to create superfluous LazyOptional instances
+            return;
+        }
         this.controller = pController;
         //noinspection ConstantConditions
         this.lazyInputHandler = LazyOptional.of(() -> controller.getInputHandler());

--- a/src/main/java/com/smashingmods/alchemistry/common/block/reactor/ReactorOutputBlockEntity.java
+++ b/src/main/java/com/smashingmods/alchemistry/common/block/reactor/ReactorOutputBlockEntity.java
@@ -29,6 +29,10 @@ public class ReactorOutputBlockEntity extends BlockEntity {
     }
 
     public void setController(@Nullable AbstractReactorBlockEntity pController) {
+        if (this.controller == pController) {
+            // No need to create superfluous LazyOptional instances
+            return;
+        }
         this.controller = pController;
         //noinspection ConstantConditions
         this.lazyOutputHandler = LazyOptional.of(() -> controller.getOutputHandler());


### PR DESCRIPTION
May cause issues with the bug that was fixed with https://github.com/SmashingMods/Alchemistry/commit/9ba7169f6c38aadbe31c49015dcbf6550ab4c9b9 but since I cannot find out any details about it (alongside reproduction steps) I'll have to assume that the commit message is right with it being a caching issues concerning capabilities. Instead of setting the block states of I/O blocks from air to their respective values we now simply update their neighbours.

Mekanism seems to respond to this, as dumping a stacktrace whenever ReactorEnergyBlockEntity#getCapability gets called shows that a call is made whenever the world is loaded (alongside external calls that could be caused by Mekanism fixing the issue on their side too).

Should fix a point raised in #306 (the immersive Engineering Wires thing), but fails to fix all issues mentioned within it (the Patchuli issue is simply beyond the scope of this PR)