### PR TITLE
Fixed Recipe Lock allowing flow-over.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -40,7 +40,6 @@ minecraft {
             property 'forge.logging.console.level', 'debug'
             property 'mixin.env.remapRefMap', 'true'
             property 'mixin.env.refMapRemappingFile', "${projectDir}/build/createSrgToMcp/output.srg"
-            jvmArgs '-XX:+AllowEnhancedClassRedefinition'
 
             mods {
                 alchemistry {
@@ -55,7 +54,6 @@ minecraft {
             property 'forge.logging.console.level', 'debug'
             property 'mixin.env.remapRefMap', 'true'
             property 'mixin.env.refMapRemappingFile', "${projectDir}/build/createSrgToMcp/output.srg"
-            jvmArgs '-XX:+AllowEnhancedClassRedefinition'
             args 'nogui'
 
             mods {
@@ -71,7 +69,6 @@ minecraft {
             property 'forge.logging.console.level', 'debug'
             property 'mixin.env.remapRefMap', 'true'
             property 'mixin.env.refMapRemappingFile', "${projectDir}/build/createSrgToMcp/output.srg"
-            jvmArgs '-XX:+AllowEnhancedClassRedefinition'
 
             args '--mod', "$archivesBaseName", '--all', '--output', file('src/generated/resources/'), '--existing', file('src/main/resources')
 
@@ -108,7 +105,11 @@ dependencies {
     runtimeOnly fg.deobf("vazkii.patchouli:Patchouli:${minecraft_version}-${patchouli_version}")
 
     runtimeOnly fg.deobf("curse.maven:ctm-267602:3737369")
-    runtimeOnly fg.deobf("curse.maven:mekanism-268560:3743835")
+    runtimeOnly fg.deobf("curse.maven:mekanism-268560:3875976")
+    //Used for testing mekanism compatibility.
+    //runtimeOnly fg.deobf("curse.maven:mekanism-generators-268566:3875978")
+    //runtimeOnly fg.deobf("curse.maven:mekanism-tools-268567:3875979")
+    //runtimeOnly fg.deobf("curse.maven:mekanism-additions-345425:3875980")
     runtimeOnly fg.deobf("curse.maven:pipez-443900:3819249")
 }
 


### PR DESCRIPTION
This is a fix for an issue I raised: [https://github.com/SmashingMods/Alchemistry/issues/326](https://github.com/SmashingMods/Alchemistry/issues/326)

In short, the combiner recipe lock does not work with mekanism logistical pipes. It allows too many items to be inserted. Please see the issue for a breakdown.

For this fix:
I have tested 2 scenarios:
Can wool and triglycerine be made?
Does the machine work without recipe lock?

Both scenarios pass my personal testing and we have begin to use my build locally on my server.

I also changed the build.gradle. The gradle appears to use java 17, but there was a command arg that appears to no longer exist, so I removed it as I could not launch the project with it.

I also added other mekanism components (commented out) to enable testing of the fix. 

Unrelated: Locally, I had to create a gradle wrapper to set the gradle version because I am using gradle 8+ for other work. I recommend this file be commit so future users can build the source out-of-the-box.