### PR TITLE
Fix "%s" in tooltips

### DIFF
--- a/src/main/java/com/smashingmods/alchemistry/common/block/atomizer/AtomizerBlock.java
+++ b/src/main/java/com/smashingmods/alchemistry/common/block/atomizer/AtomizerBlock.java
@@ -53,7 +53,7 @@ public class AtomizerBlock extends AbstractProcessingBlock {
     @Override
     public void appendHoverText(ItemStack pStack, @Nullable BlockGetter pLevel, List<Component> pTooltip, TooltipFlag pFlag) {
         super.appendHoverText(pStack, pLevel, pTooltip, pFlag);
-        pTooltip.add(MutableComponent.create(new TranslatableContents("tooltip.alchemistry.energy_requirement", String.valueOf(Config.Common.atomizerEnergyPerTick.get()), TranslatableContents.NO_ARGS)));
+        pTooltip.add(MutableComponent.create(new TranslatableContents("tooltip.alchemistry.energy_requirement", null, new Object[]{Config.Common.atomizerEnergyPerTick.get()})));
     }
 
     @Override

--- a/src/main/java/com/smashingmods/alchemistry/common/block/combiner/CombinerBlock.java
+++ b/src/main/java/com/smashingmods/alchemistry/common/block/combiner/CombinerBlock.java
@@ -56,7 +56,7 @@ public class CombinerBlock extends AbstractProcessingBlock {
     @Override
     public void appendHoverText(ItemStack pStack, @Nullable BlockGetter pLevel, List<Component> pTooltip, TooltipFlag pFlag) {
         super.appendHoverText(pStack, pLevel, pTooltip, pFlag);
-        pTooltip.add(MutableComponent.create(new TranslatableContents("tooltip.alchemistry.energy_requirement", String.valueOf(Config.Common.combinerEnergyPerTick.get()), TranslatableContents.NO_ARGS)));
+        pTooltip.add(MutableComponent.create(new TranslatableContents("tooltip.alchemistry.energy_requirement", null, new Object[]{Config.Common.combinerEnergyPerTick.get()})));
     }
 
     @Override

--- a/src/main/java/com/smashingmods/alchemistry/common/block/compactor/CompactorBlock.java
+++ b/src/main/java/com/smashingmods/alchemistry/common/block/compactor/CompactorBlock.java
@@ -53,7 +53,7 @@ public class CompactorBlock extends AbstractProcessingBlock {
     @Override
     public void appendHoverText(ItemStack pStack, @Nullable BlockGetter pLevel, List<Component> pTooltip, TooltipFlag pFlag) {
         super.appendHoverText(pStack, pLevel, pTooltip, pFlag);
-        pTooltip.add(MutableComponent.create(new TranslatableContents("tooltip.alchemistry.energy_requirement", String.valueOf(Config.Common.combinerEnergyPerTick.get()), TranslatableContents.NO_ARGS)));
+        pTooltip.add(MutableComponent.create(new TranslatableContents("tooltip.alchemistry.energy_requirement", null, new Object[]{Config.Common.combinerEnergyPerTick.get()})));
     }
 
     @Override

--- a/src/main/java/com/smashingmods/alchemistry/common/block/fission/FissionControllerBlock.java
+++ b/src/main/java/com/smashingmods/alchemistry/common/block/fission/FissionControllerBlock.java
@@ -53,7 +53,7 @@ public class FissionControllerBlock extends AbstractReactorBlock {
     @Override
     public void appendHoverText(ItemStack pStack, @Nullable BlockGetter pLevel, List<Component> pTooltip, TooltipFlag pFlag) {
         super.appendHoverText(pStack, pLevel, pTooltip, pFlag);
-        pTooltip.add(MutableComponent.create(new TranslatableContents("tooltip.alchemistry.energy_requirement", String.valueOf(Config.Common.fissionEnergyPerTick.get()), TranslatableContents.NO_ARGS)));
+        pTooltip.add(MutableComponent.create(new TranslatableContents("tooltip.alchemistry.energy_requirement", null, new Object[]{Config.Common.fissionEnergyPerTick.get()})));
     }
 
     @Override

--- a/src/main/java/com/smashingmods/alchemistry/common/block/fusion/FusionControllerBlock.java
+++ b/src/main/java/com/smashingmods/alchemistry/common/block/fusion/FusionControllerBlock.java
@@ -53,7 +53,7 @@ public class FusionControllerBlock extends AbstractReactorBlock {
     @Override
     public void appendHoverText(ItemStack pStack, @Nullable BlockGetter pLevel, List<Component> pTooltip, TooltipFlag pFlag) {
         super.appendHoverText(pStack, pLevel, pTooltip, pFlag);
-        pTooltip.add(MutableComponent.create(new TranslatableContents("tooltip.alchemistry.energy_requirement", String.valueOf(Config.Common.fusionEnergyPerTick.get()), TranslatableContents.NO_ARGS)));
+        pTooltip.add(MutableComponent.create(new TranslatableContents("tooltip.alchemistry.energy_requirement", null, new Object[]{Config.Common.fusionEnergyPerTick.get()})));
     }
 
     @Override


### PR DESCRIPTION
Tooltip of some blocks wrongly used TranslatableContents, making "%d" not working.\
This PR fixes the problem that "%d"s are not working and display as "%s". 
### Before
![Before: Atomizer](https://github.com/SmashingMods/Alchemistry/assets/76843407/903cad64-f3e1-4301-b73f-8cfca93085fd)
![Before: Compactor](https://github.com/SmashingMods/Alchemistry/assets/76843407/9181c768-7a63-493c-afdd-5be84343d56a)
![Before: Combiner](https://github.com/SmashingMods/Alchemistry/assets/76843407/5416718d-0ccb-4756-a92e-cb26ef03f27b)
### After
![After: Atomizer](https://github.com/SmashingMods/Alchemistry/assets/76843407/a5c4015c-2e66-4a40-a0c5-f83dcaf6fc86)
![After: Compactor](https://github.com/SmashingMods/Alchemistry/assets/76843407/3841d359-6077-409b-88d5-5a7cfb0fbc1d)
![After: Combiner](https://github.com/SmashingMods/Alchemistry/assets/76843407/6bf77613-3d8f-4fbd-824f-16c23cb1cb3c)
