### PR TITLE
fix: correct absolute probability display for Dissolver in JEI

### DIFF
--- a/src/main/java/com/smashingmods/alchemistry/client/jei/category/DissolverRecipeCategory.java
+++ b/src/main/java/com/smashingmods/alchemistry/client/jei/category/DissolverRecipeCategory.java
@@ -93,7 +93,10 @@ public class DissolverRecipeCategory implements IRecipeCategory<DissolverRecipe>
                 if (probabilities.size() > index) {
                     NumberFormat numberFormat = NumberFormat.getInstance();
                     numberFormat.setMaximumFractionDigits(2);
-                    double percent = (probabilities.get(index) / totalProbability) * 100;
+                    double percent = probabilities.get(index);
+                    if (weighted) {
+                        percent = (percent / totalProbability) * 100;
+                    }
                     pGuiGraphics.drawString(font, numberFormat.format(percent) + "%", x, y, 0xFFFFFFFF, true);
                 }
             }


### PR DESCRIPTION
Absolute probabilities should not be normalized, which affected the in-game probability display. For example, beetroot and chorus fruit should show 100 and 50, but were incorrectly displayed as 100/(100+50) and 50/(100+50). This fix resolves the issue.