### PR TITLE
fix: correct atomizer input for ethane recipe

### DIFF
--- a/src/generated/resources/data/alchemistry/recipes/atomizer/ethane.json
+++ b/src/generated/resources/data/alchemistry/recipes/atomizer/ethane.json
@@ -3,7 +3,7 @@
   "group": "alchemistry:atomizer",
   "input": {
     "amount": "500",
-    "fluid": "chemlib:methane_fluid"
+    "fluid": "chemlib:ethane_fluid"
   },
   "result": {
     "count": 8,


### PR DESCRIPTION
The atomizer recipe for ethane incorrectly used methane_fluid as input. It should be ethane_fluid instead. This fix resolves the issue.